### PR TITLE
feature/PI/raspbian-dockerfile-taskrunner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
-.vscode
+.vscode/*
+!important .vscode/tasks.json
+

--- a/Node/.gitignore
+++ b/Node/.gitignore
@@ -3,3 +3,5 @@
 .vscode/c_cpp_properties.json
 .vscode/launch.json
 .vscode/ipch
+.vscode/settings.json
+.vscode/extensions.json

--- a/Pidaq/.gitignore
+++ b/Pidaq/.gitignore
@@ -1,1 +1,1 @@
-important .vscode/tasks.json
+!important .vscode/tasks.json

--- a/Pidaq/.gitignore
+++ b/Pidaq/.gitignore
@@ -1,0 +1,1 @@
+!important vscode/tasks.json

--- a/Pidaq/.gitignore
+++ b/Pidaq/.gitignore
@@ -1,1 +1,1 @@
-!important vscode/tasks.json
+important .vscode/tasks.json

--- a/Pidaq/.gitignore
+++ b/Pidaq/.gitignore
@@ -1,1 +1,1 @@
-!important .vscode/tasks.json
+

--- a/Pidaq/.vscode/tasks.json
+++ b/Pidaq/.vscode/tasks.json
@@ -1,0 +1,34 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "echoTest",
+            "type": "shell",
+            "command": "echo 'Hello taskrunner test good.'",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "buildPiImage",
+            "type": "shell",
+            "command": "docker build -t pidaq:v1 docker/.",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "compileRunPiHelloWorld",
+            "type": "shell",
+            "command": "docker run -it -v /c/Hyperloop/testing-software/Pidaq:/home/data --entrypoint helloTest.sh  pidaq:v1",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        }
+    ]
+}

--- a/Pidaq/README.md
+++ b/Pidaq/README.md
@@ -5,7 +5,7 @@ This directory contains all of the code that will run on the raspberry pi. The p
 # Development
 We will be using docker to cross compile c++ for the raspberry pi
 
-Ensure docker is installed and running on your machine. Windows 10 Home does not have proper support for docker, however MUN offers a free upgrade to windows 10 education which is fully featured. The update is easy, unintrusive, and tasks less than 1 hour.
+Ensure docker is installed and running on your machine. Windows 10 Home does not have proper support for docker, however MUN offers a free upgrade to windows 10 education which is fully featured. The update is easy, unintrusive, and takes less than 1 hour.
 
 ## Taskrunner Setup Code for VsCode
 * Install vscode extension "Tasks" by actboy 168

--- a/Pidaq/README.md
+++ b/Pidaq/README.md
@@ -1,8 +1,20 @@
 # Pidaq (Rasp Pi Data Aquisitor) 
 
 This directory contains all of the code that will run on the raspberry pi. The pi will receive and parse CAN messages containing raw telemetry, apply calculations,  and create a packet(s) containing either a JSON or protobuf message to send to the control laptop via ethernet (UDP)
-*** 
-## Examples
+ 
+# Development
+We will be using docker to cross compile c++ for the raspberry pi
 
-Includes relevant examples 
-***
+Ensure docker is installed and running on your machine. Windows 10 Home does not have proper support for docker, however MUN offers a free upgrade to windows 10 education which is fully featured. The update is easy, unintrusive, and tasks less than 1 hour.
+
+## Taskrunner Setup Code for VsCode
+* Install vscode extension "Tasks" by actboy 168
+
+* Open testing-software/Pidaq folder with vscode
+
+* Replace the folder path in .vscode/tasks.json line 28 command: `compile and run Pidaq HelloWorld`, with your path. replace this -> `/c/Hyperloop/testing-software/Pidaq `
+
+* Try the task buttons in blue taskbar at bottom of vscode window:
+    * `echoTest` should print Hello taskrunner good.
+    * `buildPiImage` should build docker image `pidaq:v1`
+    * `compileRunPiHelloWorld` should print "---Hello Paradigm!!!---"

--- a/Pidaq/docker/Dockerfile
+++ b/Pidaq/docker/Dockerfile
@@ -29,3 +29,4 @@ COPY helloTest.sh /usr/local/bin
 RUN sed -i.bak 's/\r$//' /usr/local/bin/helloTest.sh && \
     chmod +x /usr/local/bin/helloTest.sh
 
+CMD /bin/bash

--- a/Pidaq/docker/Dockerfile
+++ b/Pidaq/docker/Dockerfile
@@ -1,0 +1,31 @@
+FROM raspbian/stretch:latest
+
+LABEL build-date="2020-03-01" \
+      name="Raspi + Clang for xcompiling" 
+
+RUN sudo apt update -y && \
+    sudo apt upgrade -y
+
+RUN sudo apt-get install -y \
+    git \
+    make \
+    curl \
+    xz-utils \
+    libstdc++6-4.6-dev
+
+RUN cd ~ && \ 
+    wget http://releases.llvm.org/9.0.0/clang+llvm-9.0.0-armv7a-linux-gnueabihf.tar.xz && \
+    tar -xvf clang+llvm-9.0.0-armv7a-linux-gnueabihf.tar.xz && \
+    rm clang+llvm-9.0.0-armv7a-linux-gnueabihf.tar.xz && \
+    mv clang+llvm-9.0.0-armv7a-linux-gnueabihf clang_9.0.0 && \
+    sudo mv clang_9.0.0 /usr/local && \
+    echo 'export PATH=/usr/local/clang_9.0.0/bin:$PATH' >> ~/.bashrc && \
+    echo 'export LD_LIBRARY_PATH=/usr/local/clang_9.0.0/lib:$LD_LIBRARY_PATH' >> ~/.bashrc && \
+    . ~/.bashrc && \
+    clang++ --version
+
+COPY helloTest.sh /usr/local/bin
+
+RUN sed -i.bak 's/\r$//' /usr/local/bin/helloTest.sh && \
+    chmod +x /usr/local/bin/helloTest.sh
+

--- a/Pidaq/docker/README.md
+++ b/Pidaq/docker/README.md
@@ -1,0 +1,33 @@
+# Raspbian Docker Setup
+**Developed by Mark Duffett for CompV Software**
+
+Building and running the raspbian docker container:
+
+* Docker build
+```
+docker build -t pidaq:v1 .
+```
+
+* Docker Run (open to bash prompt)
+```
+docker run -it -v path-to-PIDAQ-dir:/home/data pidaq:v1 /bin/bash
+```
+
+* Docker Run (launch script)
+```
+docker run -it -v path-to-PIDAQ-dir:/home/data --entrypoint helloTest.sh pidaq:v1
+```
+
+*Where path-to-PIDAQ-dir = `/c/Hyperloop/testing-software/Pidaq on my machine*
+
+## General Docker Commands
+* `docker --version` // Check docker version/ ensure docker is installed
+* `docker image ls` // list docker images
+
+## Remote Pi SSH Setup
+* `sudo systemctl enable ssh`
+* `sudo systemctl start ssh`
+* `ifconfig` // to get IP address of raspi
+
+Default: user=pi, password=raspberry
+

--- a/Pidaq/docker/helloTest.sh
+++ b/Pidaq/docker/helloTest.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Custom aliases
+# Test C++ Compilation
+. ~/.bashrc
+cd ~
+clang++ /home/data/docker/test_main.cpp
+./a.out
+

--- a/Pidaq/docker/test_main.cpp
+++ b/Pidaq/docker/test_main.cpp
@@ -1,0 +1,9 @@
+// Raspi cross compiling test program
+#include<iostream>
+
+int main()
+{
+    std::cout << "---Hello Paradigm!!!---";
+
+    return 0;
+}


### PR DESCRIPTION
This feature branch reuses a Dockerfile and some parts of the readme created by Mark Duffet for CompV at: https://github.com/ParadigmHyperloop/comp5-software/pull/7

```
Pidaq/docker/README.md - lower level instructions including docker commands
Pidaq/README.md - instructions for pi development and using taskrunner
```

Features:
* Dockerfile for raspbian with clang configuration
* Updated the readmes and renamed some semantic items to fit testing-software
* Vscode task runner + "Tasks" extension by actboy168 configured for one-click compile and run for raspberry pi architecture
* echoTest task to test the functionality of the task runner
* BuildPiImage task to build the PI container image, 15 minutes the first time and then ~3 seconds when the large items are cached 
* compileRunPiHelloWorld task to compile and run a "Hello World" c++ program in the raspbian image
