### PR TITLE
DTS Motor Inverter Interface initial pull request

### DIFF
--- a/Pidaq/Examples/dts_simulator/dts_simulator.py
+++ b/Pidaq/Examples/dts_simulator/dts_simulator.py
@@ -5,12 +5,13 @@ from enum import Enum
 
 import can
 
+from can_manager import CanManager
 
 class DTSSimulator:
 
     def __init__(self, bus_name: str):
         # Configure bus
-        self.bus = can.interfaces.socketcan.SocketcanBus(bus_name)
+        self.can_bus =  CanManager(bus_name) 
 
         # Configure messages
         self.temperature1 = can.Message(arbitration_id=160, dlc=8)
@@ -154,23 +155,23 @@ class DTSSimulator:
 
     def send_information_messages_10hz(self):
         time.sleep(1 / 10)
-        self.bus.send(self.temperature1)
-        self.bus.send(self.temperature2)
-        self.bus.send(self.temperature3)
-        self.bus.send(self.internal_voltages)
-        self.bus.send(self.fault_codes)
+        self.can_bus.bus.send(self.temperature1)
+        self.can_bus.bus.send(self.temperature2)
+        self.can_bus.bus.send(self.temperature3)
+        self.can_bus.bus.send(self.internal_voltages)
+        self.can_bus.bus.send(self.fault_codes)
 
     def send_information_messages_100hz(self):
         time.sleep(1 / 100)
-        self.bus.send(self.analog_input_voltages)
-        self.bus.send(self.digital_input_status)
-        self.bus.send(self.motor_position_information)
-        self.bus.send(self.current_information)
-        self.bus.send(self.voltage_information)
-        self.bus.send(self.flux_information)
-        self.bus.send(self.internal_states)
-        self.bus.send(self.torque_timer_info)
-        self.bus.send(self.modulation_index_flux_weakening)
+        self.can_bus.bus.send(self.analog_input_voltages)
+        self.can_bus.bus.send(self.digital_input_status)
+        self.can_bus.bus.send(self.motor_position_information)
+        self.can_bus.bus.send(self.current_information)
+        self.can_bus.bus.send(self.voltage_information)
+        self.can_bus.bus.send(self.flux_information)
+        self.can_bus.bus.send(self.internal_states)
+        self.can_bus.bus.send(self.torque_timer_info)
+        self.can_bus.bus.send(self.modulation_index_flux_weakening)
 
 
 def run_simulation(bus_name: str):

--- a/Pidaq/Examples/dts_simulator/dts_simulator.py
+++ b/Pidaq/Examples/dts_simulator/dts_simulator.py
@@ -1,0 +1,83 @@
+from random import random
+from enum import Enum
+
+import can
+
+class DTSStates(Enum):
+    START_STATE = 0
+    PRE_CHARGE_INITIAL = 1
+    PRE_CHARGE_ACTIVE = 2
+    PRE_CHARGE_FINISH = 3
+    WAIT = 4
+    READY = 5
+    MOTOR_RUNNING = 6
+    FAULT = 7
+    RECYCLE_POWER = 65535
+
+
+class DTSSimulator:
+    
+    def __init__(self):
+        self.temperature1 = can.Message(arbitration_id=160)
+        self.temperature2 = can.Message(arbitration_id=161)
+        self.temperature3 = can.Message(arbitration_id=162)
+        self.analog_input_voltages = can.Message(arbitration_id=163)
+        self.digital_input_status = can.Message(arbitration_id=164)
+        self.motor_position_information = can.Message(arbitration_id=165)
+        self.current_information = can.Message(arbitration_id=166)
+        self.voltage_information = can.Message(arbitration_id=167)
+        self.flux_information = can.Message(arbitration_id=168)
+        self.internal_voltages = can.Message(arbitration_id=169)
+        self.internal_states = can.Message(arbitration_id=170)
+        self.fault_codes = can.Message(arbitration_id=171)
+        self.torque_timer_info = can.Message(arbitration_id=172)
+        self.modulation_index_flux_weakening = can.Message(arbitration_id=173)
+        self.firmware_information = can.Message(arbitration_id=174)
+
+    def update_temperature1(self):
+        module_a_temperature = int(200 + random() * 5.0).to_bytes(2, 'big')
+        module_b_temperature = int(210 + random() * 4.5).to_bytes(2, 'big')
+        module_c_temperature = int(205 + random() * 3.7).to_bytes(2, 'big')
+        gate_driver_board_temperature = int(190 + random() * 6.2).to_bytes(2, 'big')
+        self.temperature1.data = [
+            module_a_temperature,
+            module_b_temperature,
+            module_c_temperature,
+            gate_driver_board_temperature
+        ]
+    
+    def update_temperature2(self):
+        control_board_temperature = int(240 + random() * 4.5).to_bytes(2, 'big')
+        rtd_1_temperature = int(230 + random() * 6.3).to_bytes(2, 'big')
+        rtd_2_temperature = int(225 + random() * 3.4).to_bytes(2, 'big')
+        rtd_3_temperature = int(220 + random() * 2.3).to_bytes(2, 'big')
+        self.temperature2.data = [
+            control_board_temperature,
+            rtd_1_temperature,
+            rtd_2_temperature,
+            rtd_3_temperature
+        ]
+    
+    def update_temperature3(self):
+        rtd_4_temperature = int(203 + random() * 2.1).to_bytes(2, 'big')
+        rtd_5_temperature = int(256 + random() * 3.9).to_bytes(2, 'big')
+        motor_temperature = int(232 + random() * 4.2).to_bytes(2, 'big')
+        torque_shudder = None # TODO once set torque value gets stored
+        self.temperature3.data = [
+            rtd_4_temperature,
+            rtd_5_temperature,
+            motor_temperature,
+            torque_shudder
+        ]
+
+    def update_analog_input_values(self):
+        analog_input_1 = int(120 + random() * 10.4).to_bytes(2, 'big')
+        analog_input_2 = int(200 + random() * 7.1).to_bytes(2, 'big')
+        analog_input_3 = int(178 + random() * 2.3).to_bytes(2, 'big')
+        analog_input_4 = int(153 + random() * 6.6).to_bytes(2, 'big')
+        self.analog_input_voltages.data = [
+            analog_input_1,
+            analog_input_2,
+            analog_input_3,
+            analog_input_4
+        ]

--- a/Pidaq/Examples/dts_simulator/dts_simulator.py
+++ b/Pidaq/Examples/dts_simulator/dts_simulator.py
@@ -169,13 +169,12 @@ class DTSSimulator:
                    self.torque_command)
 
     def check_can_timeout(self, message: can.Message):
-        if not self.last_received_command_message:
+        if self.last_received_command_message == 0:
             self.last_received_command_message = time.time()
-        if message and message.arbitration_id == 192:
-            if time.time() - self.last_received_command_message > .5:
-                sys.exit()
-            else:
-                self.last_received_command_message = time.time()
+        if message is not None and message.arbitration_id == 192:
+            self.last_received_command_message = time.time()
+        if time.time() - self.last_received_command_message > .5:
+            sys.exit()
 
     def update_temperature1(self):
         self.module_a_temp = 200 + random() * 5.0
@@ -362,10 +361,9 @@ def run_simulation(bus_name: str):
             simulator_configured = True
     while True:
         message = sim.can_bus.bus.recv(0.1)
-        if message is not None:
-            sim.check_can_timeout(message)
-            if message.arbitration_id == 192:
-                sim.read_configuration_message(message)
+        sim.check_can_timeout(message)
+        if message is not None and message.arbitration_id == 192:
+            sim.read_configuration_message(message)
         sim.update_temperature1()
         sim.update_temperature2()
         sim.update_temperature3()

--- a/Pidaq/Examples/dts_simulator/dts_simulator.py
+++ b/Pidaq/Examples/dts_simulator/dts_simulator.py
@@ -6,18 +6,6 @@ from enum import Enum
 import can
 
 
-class DTSState(Enum):
-    START_STATE = 0
-    PRE_CHARGE_INITIAL = 1
-    PRE_CHARGE_ACTIVE = 2
-    PRE_CHARGE_FINISH = 3
-    WAIT = 4
-    READY = 5
-    MOTOR_RUNNING = 6
-    FAULT = 7
-    RECYCLE_POWER = 65535
-
-
 class DTSSimulator:
 
     def __init__(self, bus_name: str):

--- a/Pidaq/Examples/dts_simulator/dts_simulator.py
+++ b/Pidaq/Examples/dts_simulator/dts_simulator.py
@@ -37,6 +37,72 @@ class DTSSimulator:
         self.firmware_information = can.Message(arbitration_id=174, dlc=8)
         self.last_received_command_message = 0
 
+    def __str__(self):
+        return f'''
+        Current DTS Sim State:
+        {self.display_temps()} 
+
+        {self.display_voltages()}
+
+        {self.display_currents()}
+
+        {self.display_motor_info()}
+        '''
+    # TODO Store integer values in class instead of byte objects for easier printing
+    def display_temps(self):
+        return f'''
+        Current Temperature Status:
+        Module A Temperature: {self.module_a_temp / 10}
+        Module B Temperature: {self.module_b_temp / 10}
+        Module C Temperature: {self.module_c_temp / 10}
+        Gate Driver Board Temperature: {self.gate_driver_board_temp / 10}
+        Control Board Temperature: {self.control_board_temp / 10}
+        RTD 1 Temperature: {self.rtd_1_temp / 10}
+        RTD 2 Temperature: {self.rtd_2_temp / 10}
+        RTD 3 Temperature: {self.rtd_4_temp / 10}
+        RTD 4 Temperature: {self.rtd_4_temp / 10}
+        RTD 5 Temperature: {self.rtd_5_temp / 10}
+        Motor Temperature: {self.motor_temp / 10}
+        '''
+
+    def display_voltages(self):
+        return f'''
+        Current Voltage Status:
+        Analog Input 1 Voltage: {self.analog_input_1 / 100}V
+        Analog Input 2 Voltage: {self.analog_input_2 / 100}V
+        Analog Input 3 Voltage: {self.analog_input_3 / 100}V
+        Analog Input 4 Voltage: {self.analog_input_4 / 100}V
+        1.5V Reference Voltage: {self.one_five_voltage_ref / 100}V
+        2.5V Reference Voltage: {self.two_five_voltage_ref / 100}V
+        5.0V Reference Voltage: {self.five_voltage_ref / 100}V
+        12V System Voltage: {self.twelve_system_voltage / 100}V
+        DC Bus Voltage: {self.dc_bus_voltage / 10}V
+        Output Voltage: {self.output_voltage / 10}V
+        VAB_Vd Voltage: {self.vab_vd_voltage / 10}V
+        VBC_Vq Voltage: {self.vbc_vq_voltage / 10}V
+        '''
+    
+    def display_currents(self):
+        return f'''
+        Current Status:
+        Phase A Current: {self.phase_a_current / 10}A
+        Phase B Current: {self.phase_b_current / 10}A
+        Phase C Current: {self.phase_c_current / 10}A
+        DC Bus Current: {self.dc_bus_current / 10}A
+        Id Feedback Current: {self.id_feedback / 10}A
+        Iq Feedback Current: {self.iq_feedback / 10}A
+        '''
+
+    def display_motor_info(self):
+        return f'''
+        Motor Position Information:
+        Motor Angle: {self.motor_angle / 10}Degrees
+        Motor Speed: {self.motor_speed}RPM
+        Electrical Output Frequency: {self.electrical_output_frequency / 10}Hz
+        Delta Filter Resolved: {self.delta_filter_resolved / 10}Degrees
+        Commanded Torque: {self.torque_command / 10} Nm
+        '''
+
     def check_can_timeout(self, message: can.Message):
         if not self.last_received_command_message:
             self.last_received_command_message = time.time()
@@ -47,84 +113,115 @@ class DTSSimulator:
                 self.last_received_command_message = time.time()
 
     def update_temperature1(self):
-        module_a_temperature = int(200 + random() * 5.0).to_bytes(2, 'little')
-        module_b_temperature = int(210 + random() * 4.5).to_bytes(2, 'little')
-        module_c_temperature = int(205 + random() * 3.7).to_bytes(2, 'little')
-        gate_driver_board_temperature = int(
-            190 + random() * 6.2).to_bytes(2, 'little')
-        self.temperature1.data = module_a_temperature + module_b_temperature + \
-            module_c_temperature + gate_driver_board_temperature
+        self.module_a_temp = 200 + random() * 5.0
+        self.module_b_temp = 210 + random() * 4.5
+        self.module_c_temp = 205 + random() * 3.7
+        self.gate_driver_board_temp = 190 + random() * 6.2
+        module_a_temp_bytes = int(self.module_a_temp).to_bytes(2, 'little')
+        module_b_temp_bytes = int(self.module_b_temp).to_bytes(2, 'little')
+        module_c_temp_bytes = int(self.module_c_temp).to_bytes(2, 'little')
+        gate_driver_board_temp_bytes = int(self.gate_driver_board_temp).to_bytes(2, 'little')
+        self.temperature1.data = module_a_temp_bytes + module_b_temp_bytes + \
+            module_c_temp_bytes + gate_driver_board_temp_bytes
 
     def update_temperature2(self):
-        control_board_temperature = int(
-            240 + random() * 4.5).to_bytes(2, 'little')
-        rtd_1_temperature = int(230 + random() * 6.3).to_bytes(2, 'little')
-        rtd_2_temperature = int(225 + random() * 3.4).to_bytes(2, 'little')
-        rtd_3_temperature = int(220 + random() * 2.3).to_bytes(2, 'little')
-        self.temperature2.data = control_board_temperature + \
-            rtd_1_temperature + rtd_2_temperature + rtd_3_temperature
+        self.control_board_temp = 240 + random() * 4.5
+        self.rtd_1_temp = 230 + random() * 6.3
+        self.rtd_2_temp = 225 + random() * 3.4
+        self.rtd_3_temp = 220 + random() * 2.3
+        control_board_temp_bytes = int(self.control_board_temp).to_bytes(2, 'little')
+        rtd_1_temp_bytes = int(self.rtd_1_temp).to_bytes(2, 'little')
+        rtd_2_temp_bytes = int(self.rtd_2_temp).to_bytes(2, 'little')
+        rtd_3_temp_bytes = int(self.rtd_3_temp).to_bytes(2, 'little')
+        self.temperature2.data = control_board_temp_bytes + \
+            rtd_1_temp_bytes + rtd_2_temp_bytes + rtd_3_temp_bytes
 
     def update_temperature3(self):
-        rtd_4_temperature = int(203 + random() * 2.1).to_bytes(2, 'little')
-        rtd_5_temperature = int(256 + random() * 3.9).to_bytes(2, 'little')
-        motor_temperature = int(232 + random() * 4.2).to_bytes(2, 'little')
+        self.rtd_4_temp = 203 + random() * 2.1
+        self.rtd_5_temp = 256 + random() * 3.9
+        self.motor_temp = 232 + random() * 4.2
+        rtd_4_temp_bytes = int(self.rtd_4_temp).to_bytes(2, 'little')
+        rtd_5_temp_bytes = int(self.rtd_5_temp).to_bytes(2, 'little')
+        motor_temp_bytes = int(self.motor_temp).to_bytes(2, 'little')
         # TODO once set torque value gets stored
-        torque_shudder = int(0).to_bytes(2, 'little')
-        self.temperature3.data = rtd_4_temperature + \
-            rtd_5_temperature + motor_temperature + torque_shudder
+        torque_shudder_bytes = int(0).to_bytes(2, 'little')
+        self.temperature3.data = rtd_4_temp_bytes + \
+            rtd_5_temp_bytes + motor_temp_bytes + torque_shudder_bytes
 
     def update_analog_input_voltages(self):
-        analog_input_1 = int(120 + random() * 10.4).to_bytes(2, 'little')
-        analog_input_2 = int(200 + random() * 7.1).to_bytes(2, 'little')
-        analog_input_3 = int(178 + random() * 2.3).to_bytes(2, 'little')
-        analog_input_4 = int(153 + random() * 6.6).to_bytes(2, 'little')
-        self.analog_input_voltages.data = analog_input_1 + \
-            analog_input_2 + analog_input_3 + analog_input_4
+        self.analog_input_1 = 120 + random() * 10.4
+        self.analog_input_2 = 200 + random() * 7.1
+        self.analog_input_3 = 178 + random() * 2.3
+        self.analog_input_4 = 153 + random() * 6.6
+        analog_input_1_bytes = int(self.analog_input_1).to_bytes(2, 'little')
+        analog_input_2_bytes = int(self.analog_input_2).to_bytes(2, 'little')
+        analog_input_3_bytes = int(self.analog_input_3).to_bytes(2, 'little')
+        analog_input_4_bytes = int(self.analog_input_4).to_bytes(2, 'little')
+        self.analog_input_voltages.data = analog_input_1_bytes + \
+            analog_input_2_bytes + analog_input_3_bytes + analog_input_4_bytes
 
     def update_digital_input_status(self):
         pass
 
     def update_motor_position_information(self):
-        motor_angle = self.direction_command.to_bytes(2, 'little')
-        motor_speed = (
-            self.speed_command if self.speed_mode_enable else self.torque_command).to_bytes(2, 'little')
-        electrical_output_frequency = int(
-            1000 + random() * 20).to_bytes(2, 'little')
-        delta_filter_resolved = int(900 + random() * 900).to_bytes(2, 'little')
-        self.motor_position_information.data = motor_angle + motor_speed + \
-            electrical_output_frequency + delta_filter_resolved
+        self.motor_angle = self.direction_command
+        self.motor_speed = self.speed_command if self.speed_mode_enable else self.torque_command
+        self.electrical_output_frequency = 1000 + random() * 20
+        self.delta_filter_resolved = 900 + random() * 900
+        motor_angle_bytes = self.direction_command.to_bytes(2, 'little')
+        motor_speed_bytes = (self.motor_speed).to_bytes(2, 'little')
+        electrical_output_frequency_bytes = int(self.electrical_output_frequency).to_bytes(2, 'little')
+        delta_filter_resolved_bytes = int(self.delta_filter_resolved).to_bytes(2, 'little')
+        self.motor_position_information.data = motor_angle_bytes + motor_speed_bytes + \
+            electrical_output_frequency_bytes + delta_filter_resolved_bytes
 
     def update_current_information(self):
-        phase_a_current = int(20 + random() * 5).to_bytes(2, 'little')
-        phase_b_current = int(20 + random() * 5).to_bytes(2, 'little')
-        phase_c_current = int(20 + random() * 5).to_bytes(2, 'little')
-        dc_bus_current = int(15 + random() * 6).to_bytes(2, 'little')
-        self.current_information.data = phase_a_current + \
-            phase_b_current + phase_c_current + dc_bus_current
+        self.phase_a_current = 20 + random() * 5
+        self.phase_b_current = 20 + random() * 5
+        self.phase_c_current = 20 + random() * 5
+        self.dc_bus_current = 15 + random() * 6
+        phase_a_current_bytes = int(self.phase_a_current).to_bytes(2, 'little')
+        phase_b_current_bytes = int(self.phase_b_current).to_bytes(2, 'little')
+        phase_c_current_bytes = int(self.phase_c_current).to_bytes(2, 'little')
+        dc_bus_current_bytes = int(self.dc_bus_current).to_bytes(2, 'little')
+        self.current_information.data = phase_a_current_bytes + \
+            phase_b_current_bytes + phase_c_current_bytes + dc_bus_current_bytes
 
     def update_voltage_information(self):
-        dc_bus_voltage = int(200 + random() * 7.1).to_bytes(2, 'little')
-        output_voltage = int(205 + random() * 5.5).to_bytes(2, 'little')
-        vab_vd_voltage = int(190 + random() * 9.1).to_bytes(2, 'little')
-        vbc_vq_voltage = int(180 + random() * 6.4).to_bytes(2, 'little')
-        self.voltage_information.data = dc_bus_voltage + \
-            output_voltage + vab_vd_voltage + vbc_vq_voltage
+        self.dc_bus_voltage = 200 + random() * 7.1
+        self.output_voltage = 205 + random() * 5.5
+        self.vab_vd_voltage = 190 + random() * 9.1
+        self.vbc_vq_voltage = 180 + random() * 6.4
+        dc_bus_voltage_bytes = int(self.dc_bus_voltage).to_bytes(2, 'little')
+        output_voltage_bytes = int(self.output_voltage).to_bytes(2, 'little')
+        vab_vd_voltage_bytes = int(self.vab_vd_voltage).to_bytes(2, 'little')
+        vbc_vq_voltage_bytes = int(self.vbc_vq_voltage).to_bytes(2, 'little')
+        self.voltage_information.data = dc_bus_voltage_bytes + \
+            output_voltage_bytes + vab_vd_voltage_bytes + vbc_vq_voltage_bytes
 
     def update_flux_information(self):
-        flux_command = int(2 + random() * .64).to_bytes(2, 'little')
-        flux_feedback = int(2 + random() * .64).to_bytes(2, 'little')
-        id_feedback = int(20 + random() * 5).to_bytes(2, 'little')
-        iq_feedback = int(20 + random() * 5).to_bytes(2, 'little')
-        self.flux_information.data = flux_command + \
-            flux_feedback + id_feedback + iq_feedback
+        self.flux_command = 2 + random() * .64
+        self.flux_feedback = 2 + random() * .64
+        self.id_feedback = 20 + random() * 5
+        self.iq_feedback = 20 + random() * 5
+        flux_command_bytes = int(self.flux_command).to_bytes(2, 'little')
+        flux_feedback_bytes = int(self.flux_feedback).to_bytes(2, 'little')
+        id_feedback_bytes = int(self.id_feedback).to_bytes(2, 'little')
+        iq_feedback_bytes = int(self.iq_feedback).to_bytes(2, 'little')
+        self.flux_information.data = flux_command_bytes + \
+            flux_feedback_bytes + id_feedback_bytes + iq_feedback_bytes
 
     def update_internal_voltages(self):
-        one_five_voltage_ref = int(150).to_bytes(2, 'little')
-        two_five_voltage_ref = int(250).to_bytes(2, 'little')
-        five_voltage_ref = int(500).to_bytes(2, 'little')
-        twelve_system_voltage = int(1200).to_bytes(2, 'little')
-        self.internal_voltages.data = one_five_voltage_ref + \
-            two_five_voltage_ref + five_voltage_ref + twelve_system_voltage
+        self.one_five_voltage_ref = 150
+        self.two_five_voltage_ref = 250
+        self.five_voltage_ref = 500
+        self.twelve_system_voltage = 1200
+        one_five_voltage_ref_bytes = int(self.one_five_voltage_ref).to_bytes(2, 'little')
+        two_five_voltage_ref_bytes = int(self.two_five_voltage_ref).to_bytes(2, 'little')
+        five_voltage_ref_bytes = int(self.five_voltage_ref).to_bytes(2, 'little')
+        twelve_system_voltage_bytes = int(self.twelve_system_voltage).to_bytes(2, 'little')
+        self.internal_voltages.data = one_five_voltage_ref_bytes + \
+            two_five_voltage_ref_bytes + five_voltage_ref_bytes + twelve_system_voltage_bytes
 
     def update_internal_states(self):
         pass
@@ -133,10 +230,11 @@ class DTSSimulator:
         pass
 
     def update_torque_timer_information(self):
-        commanded_torque = int(self.torque_command).to_bytes(2, 'little')
-        torque_feedback = int(self.torque_command).to_bytes(2, 'little')
-        power_on_timer = int(time.time() * 0.03).to_bytes(4, 'little')
-        self.internal_states.data = commanded_torque + torque_feedback + power_on_timer
+        self.power_on_timer = time.time() * 0.03
+        commanded_torque_bytes = int(self.torque_command).to_bytes(2, 'little')
+        torque_feedback_bytes = int(self.torque_command).to_bytes(2, 'little')
+        power_on_timer_bytes = int(self.power_on_timer).to_bytes(4, 'little')
+        self.internal_states.data = commanded_torque_bytes + torque_feedback_bytes + power_on_timer_bytes
 
     def update_modulation_index(self):
         pass
@@ -185,6 +283,8 @@ def run_simulation(bus_name: str):
     while True:
         message = sim.bus.recv(0.1)
         sim.check_can_timeout(message)
+        if message.arbitration_id == 192:
+            sim.read_configuration_message(message)
         sim.update_temperature1()
         sim.update_temperature2()
         sim.update_temperature3()

--- a/Pidaq/Examples/dts_simulator/dts_simulator.py
+++ b/Pidaq/Examples/dts_simulator/dts_simulator.py
@@ -9,7 +9,40 @@ from can_manager import can_manager
 
 
 class DTSSimulator:
+    ''' Class for simulating the behaviour of the DTS motor/inverter
 
+    The majority of the data sent over the can bus contains spoofed data, however
+    the simulator is able to correctly interpret command messages, and send back the correct
+    data based on the command message received.
+
+    Fields:
+        See methods, too many to list here, but all are data that the real inverter
+        sends through CAN messages
+    
+    Methods:
+        check_can_timeout(self, message)
+        display_currents(self)
+        display_motor_info(self)
+        display_temps(self)
+        display_voltages(self)
+        read_configuration_message(self)
+        send_information_messages_10Hz(self)
+        send_information_messages_100Hz(self)
+        update_analog_input_voltages(self)
+        update_current_information(self)
+        update_digital_input_status(self) - To be defined
+        update_fault_codes(self) - To be defined
+        update_flux_information(self)
+        update_internal_states(self) - To be defined
+        update_internal_voltages(self)
+        update_modulation_index(self) - To be defined
+        update_motor_position_information(self)
+        update_temperature1(self)
+        update_temperature2(self)
+        update_temperature3(self)
+        update_torque_timer_information(self)
+        update_voltage_information(self)
+    '''
     def __init__(self, bus_name: str):
         # Configure bus
         self.can_bus = can_manager.CanManager(bus_name)
@@ -49,51 +82,76 @@ class DTSSimulator:
 
         {self.display_motor_info()}
         '''
-    # TODO Store integer values in class instead of byte objects for easier printing
 
     def display_temps(self):
-        return f'''
+        return '''
         Current Temperature Status:
-        Module A Temperature: {self.module_a_temp / 10}
-        Module B Temperature: {self.module_b_temp / 10}
-        Module C Temperature: {self.module_c_temp / 10}
-        Gate Driver Board Temperature: {self.gate_driver_board_temp / 10}
-        Control Board Temperature: {self.control_board_temp / 10}
-        RTD 1 Temperature: {self.rtd_1_temp / 10}
-        RTD 2 Temperature: {self.rtd_2_temp / 10}
-        RTD 3 Temperature: {self.rtd_4_temp / 10}
-        RTD 4 Temperature: {self.rtd_4_temp / 10}
-        RTD 5 Temperature: {self.rtd_5_temp / 10}
-        Motor Temperature: {self.motor_temp / 10}
-        '''
+        Module A Temperature: {:.2f}
+        Module B Temperature: {:.2f}
+        Module C Temperature: {:.2f}
+        Gate Driver Board Temperature: {:.2f}
+        Control Board Temperature: {:.2f}
+        RTD 1 Temperature: {:.2f}
+        RTD 2 Temperature: {:.2f}
+        RTD 3 Temperature: {:.2f}
+        RTD 4 Temperature: {:.2f}
+        RTD 5 Temperature: {:.2f}
+        Motor Temperature: {:.2f}
+        '''.format(self.module_a_temp / 10,
+                   self.module_b_temp / 10,
+                   self.module_c_temp / 10,
+                   self.gate_driver_board_temp / 10,
+                   self.control_board_temp / 10,
+                   self.rtd_1_temp / 10,
+                   self.rtd_2_temp / 10,
+                   self.rtd_4_temp / 10,
+                   self.rtd_4_temp / 10,
+                   self.rtd_5_temp / 10,
+                   self.motor_temp / 10)
 
     def display_voltages(self):
-        return f'''
+        return '''
         Current Voltage Status:
-        Analog Input 1 Voltage: {self.analog_input_1 / 100}V
-        Analog Input 2 Voltage: {self.analog_input_2 / 100}V
-        Analog Input 3 Voltage: {self.analog_input_3 / 100}V
-        Analog Input 4 Voltage: {self.analog_input_4 / 100}V
-        1.5V Reference Voltage: {self.one_five_voltage_ref / 100}V
-        2.5V Reference Voltage: {self.two_five_voltage_ref / 100}V
-        5.0V Reference Voltage: {self.five_voltage_ref / 100}V
-        12V System Voltage: {self.twelve_system_voltage / 100}V
-        DC Bus Voltage: {self.dc_bus_voltage / 10}V
-        Output Voltage: {self.output_voltage / 10}V
-        VAB_Vd Voltage: {self.vab_vd_voltage / 10}V
-        VBC_Vq Voltage: {self.vbc_vq_voltage / 10}V
-        '''
+        Analog Input 1 Voltage: {:.2f}V
+        Analog Input 2 Voltage: {:.2f}V
+        Analog Input 3 Voltage: {:.2f}V
+        Analog Input 4 Voltage: {:.2f}V
+        1.5V Reference Voltage: {:.2f}V
+        2.5V Reference Voltage: {:.2f}V
+        5.0V Reference Voltage: {:.2f}V
+        12V System Voltage: {:.2f}V
+        DC Bus Voltage: {:.2f}V
+        Output Voltage: {:.2f}V
+        VAB_Vd Voltage: {:.2f}V
+        VBC_Vq Voltage: {:.2f}V
+        '''.format(self.analog_input_1 / 100,
+                   self.analog_input_2 / 100,
+                   self.analog_input_3 / 100,
+                   self.analog_input_4 / 100,
+                   self.one_five_voltage_ref / 100,
+                   self.two_five_voltage_ref / 100,
+                   self.five_voltage_ref / 100,
+                   self.twelve_system_voltage / 100,
+                   self.dc_bus_voltage / 10,
+                   self.output_voltage / 10,
+                   self.vab_vd_voltage / 10,
+                   self.vbc_vq_voltage / 10)
 
     def display_currents(self):
-        return f'''
+        return '''
         Current Status:
-        Phase A Current: {self.phase_a_current / 10}A
-        Phase B Current: {self.phase_b_current / 10}A
-        Phase C Current: {self.phase_c_current / 10}A
-        DC Bus Current: {self.dc_bus_current / 10}A
-        Id Feedback Current: {self.id_feedback / 10}A
-        Iq Feedback Current: {self.iq_feedback / 10}A
-        '''
+        Phase A Current: {:.2f}A
+        Phase B Current: {:.2f}A
+        Phase C Current: {:.2f}A
+        DC Bus Current: {:.2f}A
+        Id Feedback Current: {:.2f}A
+        Iq Feedback Current: {:.2f}A
+        '''.format(self.phase_a_current / 10,
+                   self.phase_b_current / 10,
+                   self.phase_c_current / 10,
+                   self.dc_bus_current / 10,
+                   self.id_feedback / 10,
+                   self.iq_feedback / 10)
 
     def display_motor_info(self):
         return f'''

--- a/Pidaq/Examples/dts_simulator/dts_simulator.py
+++ b/Pidaq/Examples/dts_simulator/dts_simulator.py
@@ -18,7 +18,7 @@ class DTSSimulator:
     Fields:
         See methods, too many to list here, but all are data that the real inverter
         sends through CAN messages
-    
+
     Methods:
         check_can_timeout(self, message)
         display_currents(self)
@@ -43,6 +43,7 @@ class DTSSimulator:
         update_torque_timer_information(self)
         update_voltage_information(self)
     '''
+
     def __init__(self, bus_name: str):
         # Configure bus
         self.can_bus = can_manager.CanManager(bus_name)
@@ -154,14 +155,18 @@ class DTSSimulator:
                    self.iq_feedback / 10)
 
     def display_motor_info(self):
-        return f'''
+        return '''
         Motor Position Information:
-        Motor Angle: {self.motor_angle / 10}Degrees
-        Motor Speed: {self.motor_speed}RPM
-        Electrical Output Frequency: {self.electrical_output_frequency / 10}Hz
-        Delta Filter Resolved: {self.delta_filter_resolved / 10}Degrees
-        Commanded Torque: {self.torque_command} Nm
-        '''
+        Motor Angle: {:.2f}Degrees
+        Motor Speed: {:.2f}RPM
+        Electrical Output Frequency: {:.2f}Hz
+        Delta Filter Resolved: {:.2f}Degrees
+        Commanded Torque: {:.2f} Nm
+        '''.format(self.motor_angle / 10,
+                   self.motor_speed,
+                   self.electrical_output_frequency / 10,
+                   self.delta_filter_resolved / 10,
+                   self.torque_command)
 
     def check_can_timeout(self, message: can.Message):
         if not self.last_received_command_message:

--- a/Pidaq/Examples/dts_simulator/dts_simulator.py
+++ b/Pidaq/Examples/dts_simulator/dts_simulator.py
@@ -79,12 +79,8 @@ class DTSSimulator:
         analog_input_2 = int(200 + random() * 7.1).to_bytes(2, 'big')
         analog_input_3 = int(178 + random() * 2.3).to_bytes(2, 'big')
         analog_input_4 = int(153 + random() * 6.6).to_bytes(2, 'big')
-        self.analog_input_voltages.data = [
-            analog_input_1,
-            analog_input_2,
-            analog_input_3,
-            analog_input_4
-        ]
+        self.analog_input_voltages.data = analog_input_1 + \
+            analog_input_2 + analog_input_3 + analog_input_4
 
     def update_digital_input_status(self):
         pass  # This will need to read from the state
@@ -140,16 +136,12 @@ class DTSSimulator:
         ]
 
     def update_internal_voltages(self):
-        one_five_voltage_ref = int(150).to_bytes(2, 'big')
-        two_five_voltage_ref = int(250).to_bytes(2, 'big')
-        five_voltage_ref = int(500).to_bytes(2, 'big')
-        twelve_system_voltage = int(1200).to_bytes(2, 'big')
-        self.internal_voltages = [
-            one_five_voltage_ref,
-            two_five_voltage_ref,
-            five_voltage_ref,
-            twelve_system_voltage
-        ]
+        one_five_voltage_ref = int(150).to_bytes(2, 'little')
+        two_five_voltage_ref = int(250).to_bytes(2, 'little')
+        five_voltage_ref = int(500).to_bytes(2, 'little')
+        twelve_system_voltage = int(1200).to_bytes(2, 'little')
+        self.internal_voltages.data = one_five_voltage_ref + \
+            two_five_voltage_ref + five_voltage_ref + twelve_system_voltage
 
     def update_internal_states(self):
         pass  # Read from input configuration
@@ -180,20 +172,20 @@ class DTSSimulator:
         self.bus.send(self.temperature1)
         self.bus.send(self.temperature2)
         self.bus.send(self.temperature3)
-        # self.bus.send(self.internal_voltages)
+        self.bus.send(self.internal_voltages)
         # self.bus.send(self.fault_codes)
 
     def send_information_messages_100hz(self):
         time.sleep(1 / 100)
         self.bus.send(self.analog_input_voltages)
-        self.bus.send(self.digital_input_status)
-        self.bus.send(self.motor_position_information)
-        self.bus.send(self.current_information)
-        self.bus.send(self.voltage_information)
-        self.bus.send(self.flux_information)
-        self.bus.send(self.internal_states)
-        self.bus.send(self.torque_timer_info)
-        self.bus.send(self.modulation_index_flux_weakening)
+        # self.bus.send(self.digital_input_status)
+        # self.bus.send(self.motor_position_information)
+        # self.bus.send(self.current_information)
+        # self.bus.send(self.voltage_information)
+        # self.bus.send(self.flux_information)
+        # self.bus.send(self.internal_states)
+        # self.bus.send(self.torque_timer_info)
+        # self.bus.send(self.modulation_index_flux_weakening)
 
 
 if __name__ == "__main__":
@@ -220,3 +212,4 @@ if __name__ == "__main__":
         sim.update_torque_timer_information()
         sim.update_modulation_index()
         sim.send_information_messages_10hz()
+        sim.send_information_messages_100hz()

--- a/Pidaq/Examples/dts_simulator/dts_simulator.py
+++ b/Pidaq/Examples/dts_simulator/dts_simulator.py
@@ -81,3 +81,82 @@ class DTSSimulator:
             analog_input_3,
             analog_input_4
         ]
+
+    def update_digital_input_status(self):
+        pass # This will need to read from the state
+
+    def update_motor_position_information(self):
+        pass # This will need to read from the state
+
+    def update_current_information(self):
+        phase_a_current = int(20 + random() * 5).to_bytes(2, 'big')
+        phase_b_current = int(20 + random() * 5).to_bytes(2, 'big')
+        phase_c_current = int(20 + random() * 5).to_bytes(2, 'big')
+        dc_bus_current = int(15 + random() * 6).to_bytes(2, 'big') 
+        self.current_information = [
+            phase_a_current,
+            phase_b_current,
+            phase_c_current,
+            dc_bus_current
+        ]
+
+    def update_voltage_information(self):
+        dc_bus_voltage = int(200 + random() * 7.1).to_bytes(2, 'big')
+        output_voltage = int(205 + random() * 5.5).to_bytes(2, 'big')
+        vab_vd_voltage = int(190 + random() * 9.1).to_bytes(2, 'big')
+        vbc_vq_voltage = int(180 + random() * 6.4).to_bytes(2, 'big')
+        self.voltage_information = [
+            dc_bus_voltage,
+            output_voltage,
+            vab_vd_voltage,
+            vbc_vq_voltage
+        ]
+
+    def update_flux_information(self):
+        flux_command = int(2 + random() * .64).to_bytes(2, 'big')
+        flux_feedback = int(2 + random() * .64).to_bytes(2, 'big')
+        id_feedback = int(20 + random() * 5).to_bytes(2, 'big')
+        iq_feedback = int(20 + random() * 5).to_bytes(2, 'big')
+        self.flux_information = [
+            flux_command,
+            flux_feedback,
+            id_feedback,
+            iq_feedback
+        ]
+
+    def update_internal_voltages(self):
+        one_five_voltage_ref = 150.to_bytes(2, 'big')
+        two_five_voltage_ref = 250.to_bytes(2, 'big')
+        five_voltage_ref = 500.to_bytes(2, 'big')
+        twelve_system_voltage = 1200.to_bytes(2, 'big')
+        self.internal_voltages = [
+            one_five_voltage_ref,
+            two_five_voltage_ref,
+            five_voltage_ref,
+            twelve_system_voltage
+        ]
+
+    def update_internal_states(self):
+        pass # Read from input configuration
+
+    def update_fault_codes(self):
+        pass
+
+    def update_torque_timer_information(self):
+        pass # Read from command message
+
+    def update_modulation_index(self):
+        pass
+
+    def read_configuration_message(self, message: can.Message):
+        BIT_1 = 1
+        BIT_2 = 2
+        BIT_3 = 4
+        self.torque_command = message.data[1] + message.data[0]
+        self.speed_command = message_data[3] + message.data[2]
+        self.direction_command = message.data[4]
+        self.inverter_enable = message.data[5] & BIT_1
+        self.inverter_discharge = message.data[5] & BIT_2
+        self.speed_mode_enable = message.data[5] & BIT_3 
+        self.commanded_torque_limit = message.data[7] + message.data[6]
+

--- a/Pidaq/Examples/dts_simulator/dts_simulator.py
+++ b/Pidaq/Examples/dts_simulator/dts_simulator.py
@@ -101,7 +101,18 @@ class DTSSimulator:
         pass  # This will need to read from the state
 
     def update_motor_position_information(self):
-        pass  # This will need to read from the state
+        motor_angle = None
+        # TODO Research conversion from torque to RPM for motor
+        motor_speed = (
+            self.speed_command if self.speed_mode_enable else self.torque_command).to_bytes(2, 'big')
+        electrical_output_frequency = None
+        delta_filter_resolved = None
+        self.motor_position_information = [
+            motor_angle,
+            motor_speed,
+            electrical_output_frequency,
+            delta_filter_resolved
+        ]
 
     def update_current_information(self):
         phase_a_current = int(20 + random() * 5).to_bytes(2, 'big')

--- a/Pidaq/Examples/dts_simulator/dts_simulator.py
+++ b/Pidaq/Examples/dts_simulator/dts_simulator.py
@@ -7,11 +7,12 @@ import can
 
 from can_manager import can_manager
 
+
 class DTSSimulator:
 
     def __init__(self, bus_name: str):
         # Configure bus
-        self.can_bus =  can_manager.CanManager(bus_name) 
+        self.can_bus = can_manager.CanManager(bus_name)
 
         # Configure messages
         self.temperature1 = can.Message(arbitration_id=160, dlc=8)
@@ -49,6 +50,7 @@ class DTSSimulator:
         {self.display_motor_info()}
         '''
     # TODO Store integer values in class instead of byte objects for easier printing
+
     def display_temps(self):
         return f'''
         Current Temperature Status:
@@ -81,7 +83,7 @@ class DTSSimulator:
         VAB_Vd Voltage: {self.vab_vd_voltage / 10}V
         VBC_Vq Voltage: {self.vbc_vq_voltage / 10}V
         '''
-    
+
     def display_currents(self):
         return f'''
         Current Status:
@@ -100,7 +102,7 @@ class DTSSimulator:
         Motor Speed: {self.motor_speed}RPM
         Electrical Output Frequency: {self.electrical_output_frequency / 10}Hz
         Delta Filter Resolved: {self.delta_filter_resolved / 10}Degrees
-        Commanded Torque: {self.torque_command / 10} Nm
+        Commanded Torque: {self.torque_command} Nm
         '''
 
     def check_can_timeout(self, message: can.Message):
@@ -120,7 +122,8 @@ class DTSSimulator:
         module_a_temp_bytes = int(self.module_a_temp).to_bytes(2, 'little')
         module_b_temp_bytes = int(self.module_b_temp).to_bytes(2, 'little')
         module_c_temp_bytes = int(self.module_c_temp).to_bytes(2, 'little')
-        gate_driver_board_temp_bytes = int(self.gate_driver_board_temp).to_bytes(2, 'little')
+        gate_driver_board_temp_bytes = int(
+            self.gate_driver_board_temp).to_bytes(2, 'little')
         self.temperature1.data = module_a_temp_bytes + module_b_temp_bytes + \
             module_c_temp_bytes + gate_driver_board_temp_bytes
 
@@ -129,7 +132,8 @@ class DTSSimulator:
         self.rtd_1_temp = 230 + random() * 6.3
         self.rtd_2_temp = 225 + random() * 3.4
         self.rtd_3_temp = 220 + random() * 2.3
-        control_board_temp_bytes = int(self.control_board_temp).to_bytes(2, 'little')
+        control_board_temp_bytes = int(
+            self.control_board_temp).to_bytes(2, 'little')
         rtd_1_temp_bytes = int(self.rtd_1_temp).to_bytes(2, 'little')
         rtd_2_temp_bytes = int(self.rtd_2_temp).to_bytes(2, 'little')
         rtd_3_temp_bytes = int(self.rtd_3_temp).to_bytes(2, 'little')
@@ -164,14 +168,17 @@ class DTSSimulator:
         pass
 
     def update_motor_position_information(self):
-        self.motor_angle = self.direction_command
-        self.motor_speed = self.speed_command if self.speed_mode_enable else self.torque_command
+        self.motor_angle = self.direction_command * 10
+        self.motor_speed = (
+            self.speed_command if self.speed_mode_enable else self.torque_command)
         self.electrical_output_frequency = 1000 + random() * 20
         self.delta_filter_resolved = 900 + random() * 900
         motor_angle_bytes = self.direction_command.to_bytes(2, 'little')
-        motor_speed_bytes = (self.motor_speed).to_bytes(2, 'little')
-        electrical_output_frequency_bytes = int(self.electrical_output_frequency).to_bytes(2, 'little')
-        delta_filter_resolved_bytes = int(self.delta_filter_resolved).to_bytes(2, 'little')
+        motor_speed_bytes = int(self.motor_speed * 10).to_bytes(2, 'little')
+        electrical_output_frequency_bytes = int(
+            self.electrical_output_frequency).to_bytes(2, 'little')
+        delta_filter_resolved_bytes = int(
+            self.delta_filter_resolved).to_bytes(2, 'little')
         self.motor_position_information.data = motor_angle_bytes + motor_speed_bytes + \
             electrical_output_frequency_bytes + delta_filter_resolved_bytes
 
@@ -216,10 +223,14 @@ class DTSSimulator:
         self.two_five_voltage_ref = 250
         self.five_voltage_ref = 500
         self.twelve_system_voltage = 1200
-        one_five_voltage_ref_bytes = int(self.one_five_voltage_ref).to_bytes(2, 'little')
-        two_five_voltage_ref_bytes = int(self.two_five_voltage_ref).to_bytes(2, 'little')
-        five_voltage_ref_bytes = int(self.five_voltage_ref).to_bytes(2, 'little')
-        twelve_system_voltage_bytes = int(self.twelve_system_voltage).to_bytes(2, 'little')
+        one_five_voltage_ref_bytes = int(
+            self.one_five_voltage_ref).to_bytes(2, 'little')
+        two_five_voltage_ref_bytes = int(
+            self.two_five_voltage_ref).to_bytes(2, 'little')
+        five_voltage_ref_bytes = int(
+            self.five_voltage_ref).to_bytes(2, 'little')
+        twelve_system_voltage_bytes = int(
+            self.twelve_system_voltage).to_bytes(2, 'little')
         self.internal_voltages.data = one_five_voltage_ref_bytes + \
             two_five_voltage_ref_bytes + five_voltage_ref_bytes + twelve_system_voltage_bytes
 
@@ -231,10 +242,13 @@ class DTSSimulator:
 
     def update_torque_timer_information(self):
         self.power_on_timer = time.time() * 0.03
-        commanded_torque_bytes = int(self.torque_command).to_bytes(2, 'little')
-        torque_feedback_bytes = int(self.torque_command).to_bytes(2, 'little')
+        commanded_torque_bytes = int(
+            self.torque_command * 10).to_bytes(2, 'little')
+        torque_feedback_bytes = int(
+            self.torque_command * 10).to_bytes(2, 'little')
         power_on_timer_bytes = int(self.power_on_timer).to_bytes(4, 'little')
-        self.internal_states.data = commanded_torque_bytes + torque_feedback_bytes + power_on_timer_bytes
+        self.internal_states.data = commanded_torque_bytes + \
+            torque_feedback_bytes + power_on_timer_bytes
 
     def update_modulation_index(self):
         pass
@@ -243,13 +257,16 @@ class DTSSimulator:
         BIT_1 = 1
         BIT_2 = 2
         BIT_3 = 4
-        self.torque_command = message.data[1] + message.data[0]
-        self.speed_command = message.data[3] + message.data[2]
-        self.direction_command = message.data[4]
+        self.torque_command = int.from_bytes(
+            message.data[:2], byteorder='little', signed=True) / 10
+        self.speed_command = int.from_bytes(
+            message.data[2:4], byteorder='little', signed=True) / 10
+        self.direction_command = bool(message.data[4])
         self.inverter_enable = message.data[5] & BIT_1
         self.inverter_discharge = message.data[5] & BIT_2
         self.speed_mode_enable = message.data[5] & BIT_3
-        self.commanded_torque_limit = message.data[7] + message.data[6]
+        self.commanded_torque_limit = int.from_bytes(
+            message.data[6:], byteorder='little', signed=True) / 10
 
     def send_information_messages_10hz(self):
         time.sleep(1 / 10)
@@ -276,15 +293,16 @@ def run_simulation(bus_name: str):
     sim = DTSSimulator(bus_name)
     simulator_configured = False
     while simulator_configured == False:
-        message = sim.bus.recv()
+        message = sim.can_bus.bus.recv()
         if message.arbitration_id == 192:
             sim.read_configuration_message(message)
             simulator_configured = True
     while True:
-        message = sim.bus.recv(0.1)
-        sim.check_can_timeout(message)
-        if message.arbitration_id == 192:
-            sim.read_configuration_message(message)
+        message = sim.can_bus.bus.recv(0.1)
+        if message is not None:
+            sim.check_can_timeout(message)
+            if message.arbitration_id == 192:
+                sim.read_configuration_message(message)
         sim.update_temperature1()
         sim.update_temperature2()
         sim.update_temperature3()

--- a/Pidaq/Examples/dts_simulator/dts_simulator.py
+++ b/Pidaq/Examples/dts_simulator/dts_simulator.py
@@ -1,3 +1,4 @@
+import sys
 import time
 from random import random
 from enum import Enum
@@ -20,7 +21,6 @@ class DTSState(Enum):
 class DTSSimulator:
 
     def __init__(self, bus_name: str):
-
         # Configure bus
         self.bus = can.interfaces.socketcan.SocketcanBus(bus_name)
 
@@ -46,94 +46,88 @@ class DTSSimulator:
             dlc=8
         )
         self.firmware_information = can.Message(arbitration_id=174, dlc=8)
+        self.last_received_command_message = 0
+
+    def check_can_timeout(self, message: can.Message):
+        if not self.last_received_command_message:
+            self.last_received_command_message = time.time()
+        if message and message.arbitration_id == 192:
+            if time.time() - self.last_received_command_message > .5:
+                sys.exit()
+            else:
+                self.last_received_command_message = time.time()
 
     def update_temperature1(self):
-        module_a_temperature = int(200 + random() * 5.0).to_bytes(2, 'big')
-        module_b_temperature = int(210 + random() * 4.5).to_bytes(2, 'big')
-        module_c_temperature = int(205 + random() * 3.7).to_bytes(2, 'big')
+        module_a_temperature = int(200 + random() * 5.0).to_bytes(2, 'little')
+        module_b_temperature = int(210 + random() * 4.5).to_bytes(2, 'little')
+        module_c_temperature = int(205 + random() * 3.7).to_bytes(2, 'little')
         gate_driver_board_temperature = int(
-            190 + random() * 6.2).to_bytes(2, 'big')
+            190 + random() * 6.2).to_bytes(2, 'little')
         self.temperature1.data = module_a_temperature + module_b_temperature + \
             module_c_temperature + gate_driver_board_temperature
 
     def update_temperature2(self):
         control_board_temperature = int(
-            240 + random() * 4.5).to_bytes(2, 'big')
-        rtd_1_temperature = int(230 + random() * 6.3).to_bytes(2, 'big')
-        rtd_2_temperature = int(225 + random() * 3.4).to_bytes(2, 'big')
-        rtd_3_temperature = int(220 + random() * 2.3).to_bytes(2, 'big')
+            240 + random() * 4.5).to_bytes(2, 'little')
+        rtd_1_temperature = int(230 + random() * 6.3).to_bytes(2, 'little')
+        rtd_2_temperature = int(225 + random() * 3.4).to_bytes(2, 'little')
+        rtd_3_temperature = int(220 + random() * 2.3).to_bytes(2, 'little')
         self.temperature2.data = control_board_temperature + \
             rtd_1_temperature + rtd_2_temperature + rtd_3_temperature
 
     def update_temperature3(self):
-        rtd_4_temperature = int(203 + random() * 2.1).to_bytes(2, 'big')
-        rtd_5_temperature = int(256 + random() * 3.9).to_bytes(2, 'big')
-        motor_temperature = int(232 + random() * 4.2).to_bytes(2, 'big')
+        rtd_4_temperature = int(203 + random() * 2.1).to_bytes(2, 'little')
+        rtd_5_temperature = int(256 + random() * 3.9).to_bytes(2, 'little')
+        motor_temperature = int(232 + random() * 4.2).to_bytes(2, 'little')
         # TODO once set torque value gets stored
-        torque_shudder = int(0).to_bytes(2, 'big')
+        torque_shudder = int(0).to_bytes(2, 'little')
         self.temperature3.data = rtd_4_temperature + \
             rtd_5_temperature + motor_temperature + torque_shudder
 
-    def update_analog_input_values(self):
-        analog_input_1 = int(120 + random() * 10.4).to_bytes(2, 'big')
-        analog_input_2 = int(200 + random() * 7.1).to_bytes(2, 'big')
-        analog_input_3 = int(178 + random() * 2.3).to_bytes(2, 'big')
-        analog_input_4 = int(153 + random() * 6.6).to_bytes(2, 'big')
+    def update_analog_input_voltages(self):
+        analog_input_1 = int(120 + random() * 10.4).to_bytes(2, 'little')
+        analog_input_2 = int(200 + random() * 7.1).to_bytes(2, 'little')
+        analog_input_3 = int(178 + random() * 2.3).to_bytes(2, 'little')
+        analog_input_4 = int(153 + random() * 6.6).to_bytes(2, 'little')
         self.analog_input_voltages.data = analog_input_1 + \
             analog_input_2 + analog_input_3 + analog_input_4
 
     def update_digital_input_status(self):
-        pass  # This will need to read from the state
+        pass
 
     def update_motor_position_information(self):
-        motor_angle = None
-        # TODO Research conversion from torque to RPM for motor
+        motor_angle = self.direction_command.to_bytes(2, 'little')
         motor_speed = (
-            self.speed_command if self.speed_mode_enable else self.torque_command).to_bytes(2, 'big')
-        electrical_output_frequency = None
-        delta_filter_resolved = None
-        self.motor_position_information = [
-            motor_angle,
-            motor_speed,
-            electrical_output_frequency,
-            delta_filter_resolved
-        ]
+            self.speed_command if self.speed_mode_enable else self.torque_command).to_bytes(2, 'little')
+        electrical_output_frequency = int(
+            1000 + random() * 20).to_bytes(2, 'little')
+        delta_filter_resolved = int(900 + random() * 900).to_bytes(2, 'little')
+        self.motor_position_information.data = motor_angle + motor_speed + \
+            electrical_output_frequency + delta_filter_resolved
 
     def update_current_information(self):
-        phase_a_current = int(20 + random() * 5).to_bytes(2, 'big')
-        phase_b_current = int(20 + random() * 5).to_bytes(2, 'big')
-        phase_c_current = int(20 + random() * 5).to_bytes(2, 'big')
-        dc_bus_current = int(15 + random() * 6).to_bytes(2, 'big')
-        self.current_information = [
-            phase_a_current,
-            phase_b_current,
-            phase_c_current,
-            dc_bus_current
-        ]
+        phase_a_current = int(20 + random() * 5).to_bytes(2, 'little')
+        phase_b_current = int(20 + random() * 5).to_bytes(2, 'little')
+        phase_c_current = int(20 + random() * 5).to_bytes(2, 'little')
+        dc_bus_current = int(15 + random() * 6).to_bytes(2, 'little')
+        self.current_information.data = phase_a_current + \
+            phase_b_current + phase_c_current + dc_bus_current
 
     def update_voltage_information(self):
-        dc_bus_voltage = int(200 + random() * 7.1).to_bytes(2, 'big')
-        output_voltage = int(205 + random() * 5.5).to_bytes(2, 'big')
-        vab_vd_voltage = int(190 + random() * 9.1).to_bytes(2, 'big')
-        vbc_vq_voltage = int(180 + random() * 6.4).to_bytes(2, 'big')
-        self.voltage_information = [
-            dc_bus_voltage,
-            output_voltage,
-            vab_vd_voltage,
-            vbc_vq_voltage
-        ]
+        dc_bus_voltage = int(200 + random() * 7.1).to_bytes(2, 'little')
+        output_voltage = int(205 + random() * 5.5).to_bytes(2, 'little')
+        vab_vd_voltage = int(190 + random() * 9.1).to_bytes(2, 'little')
+        vbc_vq_voltage = int(180 + random() * 6.4).to_bytes(2, 'little')
+        self.voltage_information.data = dc_bus_voltage + \
+            output_voltage + vab_vd_voltage + vbc_vq_voltage
 
     def update_flux_information(self):
-        flux_command = int(2 + random() * .64).to_bytes(2, 'big')
-        flux_feedback = int(2 + random() * .64).to_bytes(2, 'big')
-        id_feedback = int(20 + random() * 5).to_bytes(2, 'big')
-        iq_feedback = int(20 + random() * 5).to_bytes(2, 'big')
-        self.flux_information = [
-            flux_command,
-            flux_feedback,
-            id_feedback,
-            iq_feedback
-        ]
+        flux_command = int(2 + random() * .64).to_bytes(2, 'little')
+        flux_feedback = int(2 + random() * .64).to_bytes(2, 'little')
+        id_feedback = int(20 + random() * 5).to_bytes(2, 'little')
+        iq_feedback = int(20 + random() * 5).to_bytes(2, 'little')
+        self.flux_information.data = flux_command + \
+            flux_feedback + id_feedback + iq_feedback
 
     def update_internal_voltages(self):
         one_five_voltage_ref = int(150).to_bytes(2, 'little')
@@ -144,13 +138,16 @@ class DTSSimulator:
             two_five_voltage_ref + five_voltage_ref + twelve_system_voltage
 
     def update_internal_states(self):
-        pass  # Read from input configuration
+        pass
 
     def update_fault_codes(self):
         pass
 
     def update_torque_timer_information(self):
-        pass  # Read from command message
+        commanded_torque = int(self.torque_command).to_bytes(2, 'little')
+        torque_feedback = int(self.torque_command).to_bytes(2, 'little')
+        power_on_timer = int(time.time() * 0.03).to_bytes(4, 'little')
+        self.internal_states.data = commanded_torque + torque_feedback + power_on_timer
 
     def update_modulation_index(self):
         pass
@@ -173,35 +170,36 @@ class DTSSimulator:
         self.bus.send(self.temperature2)
         self.bus.send(self.temperature3)
         self.bus.send(self.internal_voltages)
-        # self.bus.send(self.fault_codes)
+        self.bus.send(self.fault_codes)
 
     def send_information_messages_100hz(self):
         time.sleep(1 / 100)
         self.bus.send(self.analog_input_voltages)
-        # self.bus.send(self.digital_input_status)
-        # self.bus.send(self.motor_position_information)
-        # self.bus.send(self.current_information)
-        # self.bus.send(self.voltage_information)
-        # self.bus.send(self.flux_information)
-        # self.bus.send(self.internal_states)
-        # self.bus.send(self.torque_timer_info)
-        # self.bus.send(self.modulation_index_flux_weakening)
+        self.bus.send(self.digital_input_status)
+        self.bus.send(self.motor_position_information)
+        self.bus.send(self.current_information)
+        self.bus.send(self.voltage_information)
+        self.bus.send(self.flux_information)
+        self.bus.send(self.internal_states)
+        self.bus.send(self.torque_timer_info)
+        self.bus.send(self.modulation_index_flux_weakening)
 
 
-if __name__ == "__main__":
-    sim = DTSSimulator('vcan0')
+def run_simulation(bus_name: str):
+    sim = DTSSimulator(bus_name)
     simulator_configured = False
     while simulator_configured == False:
         message = sim.bus.recv()
         if message.arbitration_id == 192:
             sim.read_configuration_message(message)
             simulator_configured = True
-
     while True:
+        message = sim.bus.recv(0.1)
+        sim.check_can_timeout(message)
         sim.update_temperature1()
         sim.update_temperature2()
         sim.update_temperature3()
-        # sim.update_analog_input_voltages()
+        sim.update_analog_input_voltages()
         sim.update_digital_input_status()
         sim.update_motor_position_information()
         sim.update_current_information()
@@ -209,7 +207,12 @@ if __name__ == "__main__":
         sim.update_flux_information()
         sim.update_internal_voltages()
         sim.update_internal_states()
+        sim.update_fault_codes()
         sim.update_torque_timer_information()
         sim.update_modulation_index()
         sim.send_information_messages_10hz()
         sim.send_information_messages_100hz()
+
+
+if __name__ == "__main__":
+    run_simulation('vcan0')

--- a/Pidaq/Examples/dts_simulator/dts_simulator.py
+++ b/Pidaq/Examples/dts_simulator/dts_simulator.py
@@ -5,13 +5,13 @@ from enum import Enum
 
 import can
 
-from can_manager import CanManager
+from can_manager import can_manager
 
 class DTSSimulator:
 
     def __init__(self, bus_name: str):
         # Configure bus
-        self.can_bus =  CanManager(bus_name) 
+        self.can_bus =  can_manager.CanManager(bus_name) 
 
         # Configure messages
         self.temperature1 = can.Message(arbitration_id=160, dlc=8)
@@ -301,6 +301,7 @@ def run_simulation(bus_name: str):
         sim.update_modulation_index()
         sim.send_information_messages_10hz()
         sim.send_information_messages_100hz()
+        print(sim)
 
 
 if __name__ == "__main__":

--- a/Pidaq/Examples/dts_simulator/dts_simulator.py
+++ b/Pidaq/Examples/dts_simulator/dts_simulator.py
@@ -1,7 +1,7 @@
 import sys
 import time
-from random import random
 from enum import Enum
+from random import random
 
 import can
 
@@ -9,7 +9,7 @@ from can_manager import can_manager
 
 
 class DTSSimulator:
-    ''' Class for simulating the behaviour of the DTS motor/inverter
+    """ Class for simulating the behaviour of the DTS motor/inverter
 
     The majority of the data sent over the can bus contains spoofed data, however
     the simulator is able to correctly interpret command messages, and send back the correct
@@ -42,7 +42,7 @@ class DTSSimulator:
         update_temperature3(self)
         update_torque_timer_information(self)
         update_voltage_information(self)
-    '''
+    """
 
     def __init__(self, bus_name: str):
         # Configure bus

--- a/Pidaq/Examples/dts_simulator/dts_simulator.py
+++ b/Pidaq/Examples/dts_simulator/dts_simulator.py
@@ -1,9 +1,11 @@
+import time
 from random import random
 from enum import Enum
 
 import can
 
-class DTSStates(Enum):
+
+class DTSState(Enum):
     START_STATE = 0
     PRE_CHARGE_INITIAL = 1
     PRE_CHARGE_ACTIVE = 2
@@ -16,38 +18,51 @@ class DTSStates(Enum):
 
 
 class DTSSimulator:
-    
-    def __init__(self):
-        self.temperature1 = can.Message(arbitration_id=160)
-        self.temperature2 = can.Message(arbitration_id=161)
-        self.temperature3 = can.Message(arbitration_id=162)
-        self.analog_input_voltages = can.Message(arbitration_id=163)
-        self.digital_input_status = can.Message(arbitration_id=164)
-        self.motor_position_information = can.Message(arbitration_id=165)
-        self.current_information = can.Message(arbitration_id=166)
-        self.voltage_information = can.Message(arbitration_id=167)
-        self.flux_information = can.Message(arbitration_id=168)
-        self.internal_voltages = can.Message(arbitration_id=169)
-        self.internal_states = can.Message(arbitration_id=170)
-        self.fault_codes = can.Message(arbitration_id=171)
-        self.torque_timer_info = can.Message(arbitration_id=172)
-        self.modulation_index_flux_weakening = can.Message(arbitration_id=173)
-        self.firmware_information = can.Message(arbitration_id=174)
+
+    def __init__(self, bus_name: str):
+
+        # Configure bus
+        self.bus = can.interfaces.socketcan.SocketcanBus(bus_name)
+
+        # Configure messages
+        self.temperature1 = can.Message(arbitration_id=160, dlc=8)
+        self.temperature2 = can.Message(arbitration_id=161, dlc=8)
+        self.temperature3 = can.Message(arbitration_id=162, dlc=8)
+        self.analog_input_voltages = can.Message(arbitration_id=163, dlc=8)
+        self.digital_input_status = can.Message(arbitration_id=164, dlc=8)
+        self.motor_position_information = can.Message(
+            arbitration_id=165,
+            dlc=8
+        )
+        self.current_information = can.Message(arbitration_id=166, dlc=8)
+        self.voltage_information = can.Message(arbitration_id=167, dlc=8)
+        self.flux_information = can.Message(arbitration_id=168, dlc=8)
+        self.internal_voltages = can.Message(arbitration_id=169, dlc=8)
+        self.internal_states = can.Message(arbitration_id=170, dlc=8)
+        self.fault_codes = can.Message(arbitration_id=171, dlc=8)
+        self.torque_timer_info = can.Message(arbitration_id=172, dlc=8)
+        self.modulation_index_flux_weakening = can.Message(
+            arbitration_id=173,
+            dlc=8
+        )
+        self.firmware_information = can.Message(arbitration_id=174, dlc=8)
 
     def update_temperature1(self):
         module_a_temperature = int(200 + random() * 5.0).to_bytes(2, 'big')
         module_b_temperature = int(210 + random() * 4.5).to_bytes(2, 'big')
         module_c_temperature = int(205 + random() * 3.7).to_bytes(2, 'big')
-        gate_driver_board_temperature = int(190 + random() * 6.2).to_bytes(2, 'big')
+        gate_driver_board_temperature = int(
+            190 + random() * 6.2).to_bytes(2, 'big')
         self.temperature1.data = [
             module_a_temperature,
             module_b_temperature,
             module_c_temperature,
             gate_driver_board_temperature
         ]
-    
+
     def update_temperature2(self):
-        control_board_temperature = int(240 + random() * 4.5).to_bytes(2, 'big')
+        control_board_temperature = int(
+            240 + random() * 4.5).to_bytes(2, 'big')
         rtd_1_temperature = int(230 + random() * 6.3).to_bytes(2, 'big')
         rtd_2_temperature = int(225 + random() * 3.4).to_bytes(2, 'big')
         rtd_3_temperature = int(220 + random() * 2.3).to_bytes(2, 'big')
@@ -57,12 +72,12 @@ class DTSSimulator:
             rtd_2_temperature,
             rtd_3_temperature
         ]
-    
+
     def update_temperature3(self):
         rtd_4_temperature = int(203 + random() * 2.1).to_bytes(2, 'big')
         rtd_5_temperature = int(256 + random() * 3.9).to_bytes(2, 'big')
         motor_temperature = int(232 + random() * 4.2).to_bytes(2, 'big')
-        torque_shudder = None # TODO once set torque value gets stored
+        torque_shudder = None  # TODO once set torque value gets stored
         self.temperature3.data = [
             rtd_4_temperature,
             rtd_5_temperature,
@@ -83,16 +98,16 @@ class DTSSimulator:
         ]
 
     def update_digital_input_status(self):
-        pass # This will need to read from the state
+        pass  # This will need to read from the state
 
     def update_motor_position_information(self):
-        pass # This will need to read from the state
+        pass  # This will need to read from the state
 
     def update_current_information(self):
         phase_a_current = int(20 + random() * 5).to_bytes(2, 'big')
         phase_b_current = int(20 + random() * 5).to_bytes(2, 'big')
         phase_c_current = int(20 + random() * 5).to_bytes(2, 'big')
-        dc_bus_current = int(15 + random() * 6).to_bytes(2, 'big') 
+        dc_bus_current = int(15 + random() * 6).to_bytes(2, 'big')
         self.current_information = [
             phase_a_current,
             phase_b_current,
@@ -125,10 +140,10 @@ class DTSSimulator:
         ]
 
     def update_internal_voltages(self):
-        one_five_voltage_ref = 150.to_bytes(2, 'big')
-        two_five_voltage_ref = 250.to_bytes(2, 'big')
-        five_voltage_ref = 500.to_bytes(2, 'big')
-        twelve_system_voltage = 1200.to_bytes(2, 'big')
+        one_five_voltage_ref = int(150).to_bytes(2, 'big')
+        two_five_voltage_ref = int(250).to_bytes(2, 'big')
+        five_voltage_ref = int(500).to_bytes(2, 'big')
+        twelve_system_voltage = int(1200).to_bytes(2, 'big')
         self.internal_voltages = [
             one_five_voltage_ref,
             two_five_voltage_ref,
@@ -137,13 +152,13 @@ class DTSSimulator:
         ]
 
     def update_internal_states(self):
-        pass # Read from input configuration
+        pass  # Read from input configuration
 
     def update_fault_codes(self):
         pass
 
     def update_torque_timer_information(self):
-        pass # Read from command message
+        pass  # Read from command message
 
     def update_modulation_index(self):
         pass
@@ -153,10 +168,29 @@ class DTSSimulator:
         BIT_2 = 2
         BIT_3 = 4
         self.torque_command = message.data[1] + message.data[0]
-        self.speed_command = message_data[3] + message.data[2]
+        self.speed_command = message.data[3] + message.data[2]
         self.direction_command = message.data[4]
         self.inverter_enable = message.data[5] & BIT_1
         self.inverter_discharge = message.data[5] & BIT_2
-        self.speed_mode_enable = message.data[5] & BIT_3 
+        self.speed_mode_enable = message.data[5] & BIT_3
         self.commanded_torque_limit = message.data[7] + message.data[6]
 
+    def send_information_messages_10hz(self):
+        time.sleep(1 / 10)
+        self.bus.send(self.temperature1)
+        self.bus.send(self.temperature2)
+        self.bus.send(self.temperature3)
+        self.bus.send(self.internal_voltages)
+        self.bus.send(self.fault_codes)
+
+    def send_information_messages_100hz(self):
+        time.sleep(1 / 100)
+        self.bus.send(self.analog_input_voltages)
+        self.bus.send(self.digital_input_status)
+        self.bus.send(self.motor_position_information)
+        self.bus.send(self.current_information)
+        self.bus.send(self.voltage_information)
+        self.bus.send(self.flux_information)
+        self.bus.send(self.internal_states)
+        self.bus.send(self.torque_timer_info)
+        self.bus.send(self.modulation_index_flux_weakening)

--- a/Pidaq/Examples/dts_simulator/dts_simulator.py
+++ b/Pidaq/Examples/dts_simulator/dts_simulator.py
@@ -230,12 +230,12 @@ class DTSSimulator:
         pass
 
     def update_motor_position_information(self):
-        self.motor_angle = self.direction_command * 10
+        self.motor_angle = 180 + random() * 180
         self.motor_speed = (
             self.speed_command if self.speed_mode_enable else self.torque_command)
         self.electrical_output_frequency = 1000 + random() * 20
         self.delta_filter_resolved = 900 + random() * 900
-        motor_angle_bytes = self.direction_command.to_bytes(2, 'little')
+        motor_angle_bytes = int(self.motor_angle).to_bytes(2, 'little')
         motor_speed_bytes = int(self.motor_speed * 10).to_bytes(2, 'little')
         electrical_output_frequency_bytes = int(
             self.electrical_output_frequency).to_bytes(2, 'little')
@@ -309,7 +309,7 @@ class DTSSimulator:
         torque_feedback_bytes = int(
             self.torque_command * 10).to_bytes(2, 'little')
         power_on_timer_bytes = int(self.power_on_timer).to_bytes(4, 'little')
-        self.internal_states.data = commanded_torque_bytes + \
+        self.torque_timer_info.data = commanded_torque_bytes + \
             torque_feedback_bytes + power_on_timer_bytes
 
     def update_modulation_index(self):

--- a/Pidaq/Lib/can_manager/can_manager.py
+++ b/Pidaq/Lib/can_manager/can_manager.py
@@ -64,10 +64,6 @@ class CanManager:
                     reading['reading'],
                     reading['conversion_factor'],
                 )
-<<<<<<< HEAD
-=======
-                self.message_ids.append(reading['message_id'])
->>>>>>> Bug fixes to get interface to begin sucessfully receving messages from the simulator
 
     def send_message(self, id: int, data: list) -> None:
         if id in self.messages.keys():
@@ -89,15 +85,9 @@ class CanManager:
         Parameters:
             bus_message(can.Message)
         """
-<<<<<<< HEAD
         message_id = bus_message.arbitration_id
         if message_id in self.messages.keys():
             self.messages[message_id].data = bus_message.data
-=======
-        message_id = hex(bus_message.arbitration_id)
-        if message_id in self.message_ids:
-            self.messages[message_id].data = bytes(bus_message.data)
->>>>>>> Bug fixes to get interface to begin sucessfully receving messages from the simulator
 
 
 class SensorReading:
@@ -114,15 +104,9 @@ class SensorReading:
         data (int or float)
     """
 
-<<<<<<< HEAD
     def __init__(self, message_id: str, reading: str,
                  conversion_factor) -> None:
         self.message_id = message_id
-=======
-    def __init__(self, project: str, message_id: str, reading: str,
-                 conversion_factor) -> None:
-        self.message_id = int(message_id, 16)
->>>>>>> Bug fixes to get interface to begin sucessfully receving messages from the simulator
         self.reading = reading
         self.conversion_factor = conversion_factor
         self.data = None
@@ -137,11 +121,7 @@ if __name__ == "__main__":
     bus.read_message_config('dts', 'example_message_config.json')
 
     # Print SensorReading objects
-<<<<<<< HEAD
     for id, message in bus.messages.items():
-=======
-    for message in bus.messages:
->>>>>>> Bug fixes to get interface to begin sucessfully receving messages from the simulator
         print(
             f'Message id: {message.message_id}    Reading: {message.reading}    Conversion Factor: {message.conversion_factor}')
 

--- a/Pidaq/Lib/can_manager/can_manager.py
+++ b/Pidaq/Lib/can_manager/can_manager.py
@@ -105,8 +105,8 @@ class SensorReading:
     Attributes:
         message_id (int): represents the can arbitration id, is a hexidecimal integer
         reading (str): contains the name of the measurement
-        conversion_factor: contains the conversion factor for the reading, or a dict of factors
-                           there are multiple
+        conversion_factor: contains the conversion factor for the reading,
+                            or a dict of factors if there are multiple
         data (int or float)
     """
 

--- a/Pidaq/Lib/can_manager/can_manager.py
+++ b/Pidaq/Lib/can_manager/can_manager.py
@@ -64,6 +64,10 @@ class CanManager:
                     reading['reading'],
                     reading['conversion_factor'],
                 )
+<<<<<<< HEAD
+=======
+                self.message_ids.append(reading['message_id'])
+>>>>>>> Bug fixes to get interface to begin sucessfully receving messages from the simulator
 
     def send_message(self, id: int, data: list) -> None:
         if id in self.messages.keys():
@@ -85,9 +89,15 @@ class CanManager:
         Parameters:
             bus_message(can.Message)
         """
+<<<<<<< HEAD
         message_id = bus_message.arbitration_id
         if message_id in self.messages.keys():
             self.messages[message_id].data = bus_message.data
+=======
+        message_id = hex(bus_message.arbitration_id)
+        if message_id in self.message_ids:
+            self.messages[message_id].data = bytes(bus_message.data)
+>>>>>>> Bug fixes to get interface to begin sucessfully receving messages from the simulator
 
 
 class SensorReading:
@@ -104,9 +114,15 @@ class SensorReading:
         data (int or float)
     """
 
+<<<<<<< HEAD
     def __init__(self, message_id: str, reading: str,
                  conversion_factor) -> None:
         self.message_id = message_id
+=======
+    def __init__(self, project: str, message_id: str, reading: str,
+                 conversion_factor: str, conversion_factor_type: str) -> None:
+        self.message_id = int(message_id, 16)
+>>>>>>> Bug fixes to get interface to begin sucessfully receving messages from the simulator
         self.reading = reading
         self.conversion_factor = conversion_factor
         self.data = None
@@ -121,7 +137,11 @@ if __name__ == "__main__":
     bus.read_message_config('dts', 'example_message_config.json')
 
     # Print SensorReading objects
+<<<<<<< HEAD
     for id, message in bus.messages.items():
+=======
+    for message in bus.messages:
+>>>>>>> Bug fixes to get interface to begin sucessfully receving messages from the simulator
         print(
             f'Message id: {message.message_id}    Reading: {message.reading}    Conversion Factor: {message.conversion_factor}')
 

--- a/Pidaq/Lib/can_manager/can_manager.py
+++ b/Pidaq/Lib/can_manager/can_manager.py
@@ -62,7 +62,7 @@ class CanManager:
                 self.messages[message_id] = SensorReading(
                     reading['message_id'],
                     reading['reading'],
-                    reading['conversion_factor'],
+                    reading['conversion_factor'] if reading['conversion_factor'] else None,
                 )
 
     def send_message(self, id: int, data: list) -> None:

--- a/Pidaq/Lib/can_manager/can_manager.py
+++ b/Pidaq/Lib/can_manager/can_manager.py
@@ -120,7 +120,7 @@ class SensorReading:
         self.message_id = message_id
 =======
     def __init__(self, project: str, message_id: str, reading: str,
-                 conversion_factor: str, conversion_factor_type: str) -> None:
+                 conversion_factor) -> None:
         self.message_id = int(message_id, 16)
 >>>>>>> Bug fixes to get interface to begin sucessfully receving messages from the simulator
         self.reading = reading

--- a/Pidaq/Lib/can_manager/can_manager.py
+++ b/Pidaq/Lib/can_manager/can_manager.py
@@ -99,8 +99,8 @@ class SensorReading:
     Attributes:
         message_id (int): represents the can arbitration id, is a hexidecimal integer
         reading (str): contains the name of the measurement
-        conversion_factor (int or float)
-        conversion_factor_type (str)
+        conversion_factor: contains the conversion factor for the reading, or a dict of factors
+                           there are multiple
         data (int or float)
     """
 

--- a/Pidaq/Lib/can_manager/can_manager.py
+++ b/Pidaq/Lib/can_manager/can_manager.py
@@ -71,6 +71,11 @@ class CanManager:
         message = can.Message(arbitration_id=id, data=data)
         self.bus.send(message)
 
+    def send_message_periodic(self, message: can.Message, duration: float):
+        if message.arbitration_id in self.messages.keys():
+            raise Exception(f'Error: ID: {id} is already in use')
+        return self.bus.send_periodic(message, 0.2, duration=duration)
+
     def read_bus(self, timeout_seconds=None) -> can.Message:
         message = self.bus.recv(timeout_seconds)
         return message

--- a/Pidaq/Lib/can_manager/can_manager.py
+++ b/Pidaq/Lib/can_manager/can_manager.py
@@ -36,9 +36,10 @@ class CanManager:
             assigns data to the correct SensorReading object
     """
 
-    def __init__(self, bus_name: str) -> None:
+    def __init__(self, bus_name: str, message_frequency: float) -> None:
         self.bus = can.interfaces.socketcan.SocketcanBus(channel=bus_name)
         self.messages = {}
+        self.message_frequency = message_frequency
 
     def read_message_config(self, project: str, config_file: str, path=None) -> None:
         """Reads sensor readings configuration from messageconfig.json
@@ -74,7 +75,7 @@ class CanManager:
     def send_message_periodic(self, message: can.Message, duration: float):
         if message.arbitration_id in self.messages.keys():
             raise Exception(f'Error: ID: {id} is already in use')
-        return self.bus.send_periodic(message, 0.2, duration=duration)
+        return self.bus.send_periodic(message, self.message_frequency, duration=duration)
 
     def read_bus(self, timeout_seconds=None) -> can.Message:
         message = self.bus.recv(timeout_seconds)

--- a/Pidaq/Lib/dts_manager/dts_manager.py
+++ b/Pidaq/Lib/dts_manager/dts_manager.py
@@ -497,7 +497,7 @@ class DTS():
 
         def update_data(self):
             """ Calls the update methods as necessary
- 
+
             Reads the can bus for the current message, assigns the message to the correct
             sensor reading object, and calls the respective update methods to update data
             fields based on the data type stored in the message
@@ -523,7 +523,8 @@ class DTS():
 
 if __name__ == "__main__":
     import random
-    bus = can_manager.CanManager('vcan0')
+    message_frequency = 0.2
+    bus = can_manager.CanManager('vcan0', message_frequency)
     dts = DTS(bus)
     bus.read_message_config('dts', 'message_config.json')
 
@@ -562,3 +563,4 @@ if __name__ == "__main__":
         print('2.5V Ref Voltage: {}'.format(dts.telemetry.two_five_voltage_ref))
         print('Vab Vd Voltage: {}'.format(dts.telemetry.vab_vd_voltage))
         print('Vbc Vq Voltage: {}\n'.format(dts.telemetry.vbc_vq_voltage))
+

--- a/Pidaq/Lib/dts_manager/dts_manager.py
+++ b/Pidaq/Lib/dts_manager/dts_manager.py
@@ -1,5 +1,6 @@
 from can_manager import can_manager
 
+
 class DTSControl():
 
     def __init__(self, bus: can_manager.CanManager):
@@ -68,98 +69,98 @@ class DTSTelemetry():
         self.commanded_torque = None
 
     def convert_temperatures(self) -> None:
-        if self.bus.messages['0xa0'].data:
+        if self.bus.messages[160].data:
             self.module_a_temperature = int.from_bytes(
-                self.bus.messages['0xa0'].data[0:2], byteorder='little', signed=True) / 10
+                self.bus.messages[160].data[0:2], byteorder='little', signed=True) / 10
             self.module_b_temperature = int.from_bytes(
-                self.bus.messages['0xa0'].data[2:4], byteorder='little', signed=True) / 10
+                self.bus.messages[160].data[2:4], byteorder='little', signed=True) / 10
             self.module_c_temperature = int.from_bytes(
-                self.bus.messages['0xa0'].data[4:6], byteorder='little', signed=True) / 10
+                self.bus.messages[160].data[4:6], byteorder='little', signed=True) / 10
             self.gate_driver_board_temperature = int.from_bytes(
-                self.bus.messages['0xa0'].data[6:], byteorder='little', signed=True) / 10
-        if self.bus.messages['0xa1'].data:
+                self.bus.messages[160].data[6:], byteorder='little', signed=True) / 10
+        if self.bus.messages[161].data:
             self.control_board_temperature = int.from_bytes(
-                self.bus.messages['0xa1'].data[0:2], byteorder='little', signed=True) / 10
+                self.bus.messages[161].data[0:2], byteorder='little', signed=True) / 10
             self.rtd_1_temperature = int.from_bytes(
-                self.bus.messages['0xa1'].data[2:4], byteorder='little', signed=True) / 10
+                self.bus.messages[161].data[2:4], byteorder='little', signed=True) / 10
             self.rtd_2_temperature = int.from_bytes(
-                self.bus.messages['0xa1'].data[4:6], byteorder='little', signed=True) / 10
+                self.bus.messages[161].data[4:6], byteorder='little', signed=True) / 10
             self.rtd_3_temperature = int.from_bytes(
-                self.bus.messages['0xa1'].data[6:], byteorder='little', signed=True) / 10
-        if self.bus.messages['0xa2'].data:
+                self.bus.messages[161].data[6:], byteorder='little', signed=True) / 10
+        if self.bus.messages[162].data:
             self.rtd_4_temperature = int.from_bytes(
-                self.bus.messages['0xa2'].data[0:2], byteorder='little', signed=True) / 10
+                self.bus.messages[162].data[0:2], byteorder='little', signed=True) / 10
             self.rtd_5_temperature = int.from_bytes(
-                self.bus.messages['0xa2'].data[2:4], byteorder='little', signed=True) / 10
+                self.bus.messages[162].data[2:4], byteorder='little', signed=True) / 10
             self.motor_temperature = int.from_bytes(
-                self.bus.messages['0xa2'].data[4:6], byteorder='little', signed=True) / 10
+                self.bus.messages[162].data[4:6], byteorder='little', signed=True) / 10
 
     def convert_low_voltages(self) -> None:
-        if self.bus.messages['0xa3'].data:
+        if self.bus.messages[163].data:
             self.analog_input_1 = int.from_bytes(
-                self.bus.messages['0xa3'].data[0:2], byteorder='little', signed=True) / 100
+                self.bus.messages[163].data[0:2], byteorder='little', signed=True) / 100
             self.analog_input_2 = int.from_bytes(
-                self.bus.messages['0xa3'].data[2:4], byteorder='little', signed=True) / 100
+                self.bus.messages[163].data[2:4], byteorder='little', signed=True) / 100
             self.analog_input_3 = int.from_bytes(
-                self.bus.messages['0xa3'].data[4:6], byteorder='little', signed=True) / 100
+                self.bus.messages[163].data[4:6], byteorder='little', signed=True) / 100
             self.analog_input_4 = int.from_bytes(
-                self.bus.messages['0xa3'].data[6:], byteorder='little', signed=True) / 100
-        if self.bus.messages['0xa9'].data:
+                self.bus.messages[163].data[6:], byteorder='little', signed=True) / 100
+        if self.bus.messages[169].data:
             self.one_five_voltage_ref = int.from_bytes(
-                self.bus.messages['0xa9'].data[0:2], byteorder='little', signed=True) / 100
+                self.bus.messages[169].data[0:2], byteorder='little', signed=True) / 100
             self.two_five_voltage_ref = int.from_bytes(
-                self.bus.messages['0xa9'].data[2:4], byteorder='little', signed=True) / 100
+                self.bus.messages[169].data[2:4], byteorder='little', signed=True) / 100
             self.five_voltage_ref = int.from_bytes(
-                self.bus.messages['0xa9'].data[4:6], byteorder='little', signed=True) / 100
+                self.bus.messages[169].data[4:6], byteorder='little', signed=True) / 100
             self.twelve_system_voltage = int.from_bytes(
-                self.bus.messages['0xa9'].data[6:], byteorder='little', signed=True) / 100
+                self.bus.messages[169].data[6:], byteorder='little', signed=True) / 100
 
     def convert_high_voltages(self) -> None:
-        if self.bus.messages['0xa7'].data:
+        if self.bus.messages[167].data:
             self.dc_bus_voltage = int.from_bytes(
-                self.bus.messages['0xa7'].data[0:2], byteorder='little', signed=True) / 10
+                self.bus.messages[167].data[0:2], byteorder='little', signed=True) / 10
             self.output_voltage = int.from_bytes(
-                self.bus.messages['0xa7'].data[2:4], byteorder='little', signed=True) / 10
+                self.bus.messages[167].data[2:4], byteorder='little', signed=True) / 10
             self.vab_vd_voltage = int.from_bytes(
-                self.bus.messages['0xa7'].data[4:6], byteorder='little', signed=True) / 10
+                self.bus.messages[167].data[4:6], byteorder='little', signed=True) / 10
             self.vbc_vq_voltage = int.from_bytes(
-                self.bus.messages['0xa7'].data[6:], byteorder='little', signed=True) / 10
+                self.bus.messages[167].data[6:], byteorder='little', signed=True) / 10
 
     def convert_currents(self) -> None:
-        if self.bus.messages['0xa6'].data:
+        if self.bus.messages[166].data:
             self.phase_a_current = int.from_bytes(
-                self.bus.messages['0xa6'].data[0:2], byteorder='little', signed=True) / 10
+                self.bus.messages[166].data[0:2], byteorder='little', signed=True) / 10
             self.phase_b_current = int.from_bytes(
-                self.bus.messages['0xa6'].data[2:4], byteorder='little', signed=True) / 10
+                self.bus.messages[166].data[2:4], byteorder='little', signed=True) / 10
             self.phase_c_current = int.from_bytes(
-                self.bus.messages['0xa6'].data[4:6], byteorder='little', signed=True) / 10
+                self.bus.messages[166].data[4:6], byteorder='little', signed=True) / 10
             self.dc_bus_current = int.from_bytes(
-                self.bus.messages['0xa6'].data[6:], byteorder='little', signed=True) / 10
-        if self.bus.messages['0xa8'].data:
+                self.bus.messages[166].data[6:], byteorder='little', signed=True) / 10
+        if self.bus.messages[168].data:
             self.id_feedback = int.from_bytes(
-                self.bus.messages['0xa8'].data[4:6], byteorder='little', signed=True) / 10
+                self.bus.messages[168].data[4:6], byteorder='little', signed=True) / 10
             self.iq_feedback = int.from_bytes(
-                self.bus.messages['0xa8'].data[6:], byteorder='little', signed=True) / 10
+                self.bus.messages[168].data[6:], byteorder='little', signed=True) / 10
 
     def convert_angles(self) -> None:
-        if self.bus.messages['0xa5'].data:
+        if self.bus.messages[165].data:
             self.motor_angle = int.from_bytes(
-                self.bus.messages['0xa5'].data[0:2], byteorder='little', signed=True) / 10
+                self.bus.messages[165].data[0:2], byteorder='little', signed=True) / 10
             self.delta_filter_resolved = int.from_bytes(
-                self.bus.messages['0xa5'].data[6:], byteorder='little', signed=True) / 10
+                self.bus.messages[165].data[6:], byteorder='little', signed=True) / 10
 
     def convert_booleans(self) -> None:
-        BIT_0 = 1<<0
-        BIT_1 = 1<<1
-        BIT_2 = 1<<2
-        BIT_3 = 1<<3
-        BIT_4 = 1<<4
-        BIT_5 = 1<<5
-        BIT_6 = 1<<6
-        BIT_7 = 1<<7
-        if self.bus.messages['0xa4']:
+        BIT_0 = 1 << 0
+        BIT_1 = 1 << 1
+        BIT_2 = 1 << 2
+        BIT_3 = 1 << 3
+        BIT_4 = 1 << 4
+        BIT_5 = 1 << 5
+        BIT_6 = 1 << 6
+        BIT_7 = 1 << 7
+        if self.bus.messages[164]:
             digital_input_status = int.from_bytes(
-                self.bus.messages['0xa4'].data[0:], byteorder='little', signed=False)
+                self.bus.messages[164].data[0:], byteorder='little', signed=False)
             self.digital_input_1 = bool(digital_input_status & BIT_0)
             self.digital_input_2 = bool(digital_input_status & BIT_1)
             self.digital_input_3 = bool(digital_input_status & BIT_2)
@@ -170,14 +171,14 @@ class DTSTelemetry():
             self.digital_input_8 = bool(digital_input_status & BIT_7)
 
     def convert_torques(self) -> None:
-        if self.bus.messages['0xa2'].data:
+        if self.bus.messages[162].data:
             self.torque_shudder = int.from_bytes(
-                self.bus.messages['0xa2'].data[6:], byteorder='little', signed=True) / 10
-        if self.bus.messages['0xac'].data:
+                self.bus.messages[162].data[6:], byteorder='little', signed=True) / 10
+        if self.bus.messages[172].data:
             self.commanded_torque = int.from_bytes(
-                self.bus.messages['0xac'].data[0:2], byteorder='little', signed=True) / 10
+                self.bus.messages[172].data[0:2], byteorder='little', signed=True) / 10
             self.torque_feedback = int.from_bytes(
-                self.bus.messages['0xac'].data[2:4], byteorder='little', signed=True) / 10
+                self.bus.messages[172].data[2:4], byteorder='little', signed=True) / 10
 
 
 if __name__ == "__main__":

--- a/Pidaq/Lib/dts_manager/dts_manager.py
+++ b/Pidaq/Lib/dts_manager/dts_manager.py
@@ -72,6 +72,8 @@ class DTS():
             speed_mode_enable (int)
             mode (int)
             commanded_torque_limit (int)
+            message_offset (int)
+            command_id (int)
 
         Methods:
             configure_motor(self, configuration=MotorConfig()) -> None:
@@ -117,7 +119,16 @@ class DTS():
                 self.direction_command + self.mode + self.commanded_torque_limit
             self.bus.send_message(self.command_id, command_list)
 
-        def send_motor_command(self, command, mode=InverterMode.Torque):
+        def send_motor_command(self, command: float, mode=InverterMode.Torque):
+            """ Sends a motor command using existing info plus new speed/torque command and mode
+            
+            Uses all existing message configuration except for speed/torque command, and mode.
+            Can be used to issue subsequent commands after the motor has been configured intially
+
+            Args:
+                command (float): New speed/torque command, depending on the mode
+                mode (InverterMode)
+            """ 
             speed_command = int(command if mode == InverterMode.Speed else 0).to_bytes(2, 'little')
             torque_commmand = (command if mode == InverterMode.Torque else 0).to_bytes(2, 'little')
             mode = ((int(self.mode.value) << 2) +
@@ -143,6 +154,21 @@ class DTS():
             convert_low_voltages(self)
             convert_torques(self)
             convert_temperatures(self)
+            Data Getters:
+                get_analog_input_voltages_data(self)
+                get_current_data(self)
+                get_digital_input_status_data(self)
+                get_faults_data(self)
+                get_flux_data(self)
+                get_internal_states_data(self)
+                get_internal_voltages_data(self)
+                get_modulation_index_data(self)
+                get_motor_position_data(self)
+                get_temp1_data(self)
+                get_temp2_data(self)
+                get_temp3_data(self)
+                get_torque_timer_data(self)
+                get_voltage_data(self)
         '''
 
         def __init__(self, bus: can_manager.CanManager):

--- a/Pidaq/Lib/dts_manager/dts_manager.py
+++ b/Pidaq/Lib/dts_manager/dts_manager.py
@@ -10,18 +10,23 @@ class DTSManager:
 
     def configure_motor(self, configuration: dict) -> None:
         # Extract commands from dict
-        torque_command = int(configuration['torque']).to_bytes(2, 'big')
-        speed_command = int(configuration['speed']).to_bytes(2, 'big')
-        direction_command = int(configuration['direction']).to_bytes(1, 'big')
-        inverter_enable = int(configuration['inverterEnable'])
-        inverter_discharge = int(configuration['inverterDischarge'])
-        speed_mode_enable = int(configuration['speedModeEnable'])
-        mode = ((int(speed_mode_enable) << 2) +
-                (int(inverter_discharge) << 1) + (int(inverter_enable) << 0)).to_bytes(1, 'big')
-        commanded_torque_limit = int(
+        self.torque_command = int(configuration['torque']).to_bytes(2, 'big')
+        self.speed_command = int(configuration['speed']).to_bytes(2, 'big')
+        self.direction_command = int(
+            configuration['direction']).to_bytes(1, 'big')
+        self.inverter_enable = int(configuration['inverterEnable'])
+        self.inverter_discharge = int(configuration['inverterDischarge'])
+        self.speed_mode_enable = int(configuration['speedModeEnable'])
+        self.mode = ((int(self.speed_mode_enable) << 2) +
+                     (int(self.inverter_discharge) << 1) + (int(self.inverter_enable) << 0)).to_bytes(1, 'big')
+        self.commanded_torque_limit = int(
             configuration['commandedTorqueLimit']).to_bytes(2, 'big')
 
-        # Create 8 Byte message
-        command_list = bytes(torque_command, speed_command,
-                             direction_command, mode, commanded_torque_limit)
+    def send_motor_command(self) -> None:
+        command_list = bytes(self.torque_command, self.speed_command,
+                             self.direction_command, self.mode, self.commanded_torque_limit)
         self.bus.send_message(192, command_list)
+
+    def convert_temperatures(self) -> None:
+        module_a_temperature = int.from_bytes(self.bus.messages['0x0A0'].data[1] +
+                                              self.bus.messages['0x0A0'].data[0], byteorder='big')

--- a/Pidaq/Lib/dts_manager/dts_manager.py
+++ b/Pidaq/Lib/dts_manager/dts_manager.py
@@ -19,10 +19,26 @@ class DTSManager:
         self.analog_input_2 = None
         self.analog_input_3 = None
         self.analog_input_4 = None
+        self.dc_bus_voltage = None
+        self.output_voltage = None
+        self.vab_vd_voltage = None
+        self.vbc_vq_voltage = None
+        self.motor_angle = None
+        self.delta_filter_resolved = None
         self.one_five_voltage_ref = None
         self.two_five_voltage_ref = None
         self.five_voltage_ref = None
         self.twelve_system_voltage = None
+        self.digital_input_1 = None
+        self.digital_input_2 = None
+        self.digital_input_3 = None
+        self.digital_input_4 = None
+        self.digital_input_5 = None
+        self.digital_input_6 = None
+        self.digital_input_7 = None
+        self.digital_input_8 = None
+        self.id_feedback = None
+        self.iq_feedback = None
 
     def configure_motor(self, configuration: dict) -> None:
         # Extract commands from dict
@@ -90,6 +106,17 @@ class DTSManager:
             self.twelve_system_voltage = int.from_bytes(
                 self.bus.messages['0xa9'].data[6:], byteorder='little') / 100
 
+    def convert_high_voltages(self) -> None:
+        if self.bus.messages['0xa7'].data:
+            self.dc_bus_voltage = int.from_bytes(
+                self.bus.messages['0xa7'].data[0:2], byteorder='little') / 10
+            self.output_voltage = int.from_bytes(
+                self.bus.messages['0xa7'].data[2:4], byteorder='little') / 10
+            self.vab_vd_voltage = int.from_bytes(
+                self.bus.messages['0xa7'].data[4:6], byteorder='little') / 10
+            self.vbc_vq_voltage = int.from_bytes(
+                self.bus.messages['0xa7'].data[6:], byteorder='little') / 10
+
     def convert_currents(self) -> None:
         if self.bus.messages['0xa6'].data:
             self.phase_a_current = int.from_bytes(
@@ -100,6 +127,39 @@ class DTSManager:
                 self.bus.messages['0xa6'].data[4:6], byteorder='little') / 10
             self.dc_bus_current = int.from_bytes(
                 self.bus.messages['0xa6'].data[6:], byteorder='little') / 10
+        if self.bus.messages['0xa8'].data:
+            self.id_feedback = int.from_bytes(
+                self.bus.messages['0xa8'].data[4:6], byteorder='little') / 10
+            self.iq_feedback = int.from_bytes(
+                self.bus.messages['0xa8'].data[6:], byteorder='little') / 10
+
+    def convert_angles(self) -> None:
+        if self.bus.messages['0xa5'].data:
+            self.motor_angle = int.from_bytes(
+                self.bus.messages['0xa5'].data[0:2], byteorder='little') / 10
+            self.delta_filter_resolved = int.from_bytes(
+                self.bus.messages['0xa5'].data[6:], byteorder='little') / 10
+
+    def convert_booleans(self) -> None:
+        BIT_0 = 1
+        BIT_1 = 2
+        BIT_2 = 4
+        BIT_3 = 8
+        BIT_4 = 16
+        BIT_5 = 32
+        BIT_6 = 64
+        BIT_7 = 128
+        if self.bus.messages['0xa4']:
+            digital_input_status = int.from_bytes(
+                self.bus.messages['0xa4'].data[0:], byteorder='little')
+            self.digital_input_1 = bool(digital_input_status & BIT_0)
+            self.digital_input_2 = bool(digital_input_status & BIT_1)
+            self.digital_input_3 = bool(digital_input_status & BIT_2)
+            self.digital_input_4 = bool(digital_input_status & BIT_3)
+            self.digital_input_5 = bool(digital_input_status & BIT_4)
+            self.digital_input_6 = bool(digital_input_status & BIT_5)
+            self.digital_input_7 = bool(digital_input_status & BIT_6)
+            self.digital_input_8 = bool(digital_input_status & BIT_7)
 
     def convert_torques(self) -> None:
         pass

--- a/Pidaq/Lib/dts_manager/dts_manager.py
+++ b/Pidaq/Lib/dts_manager/dts_manager.py
@@ -28,5 +28,11 @@ class DTSManager:
         self.bus.send_message(192, command_list)
 
     def convert_temperatures(self) -> None:
-        module_a_temperature = int.from_bytes(self.bus.messages['0x0A0'].data[1] +
+        self.module_a_temperature = int.from_bytes(self.bus.messages['0x0A0'].data[1] +
                                               self.bus.messages['0x0A0'].data[0], byteorder='big')
+        self.module_b_temperature = int.from_bytes(self.bus.messages['0x0A0'].data[3] +
+                                              self.bus.messages['0x0A0'].data[2], byteorder='big')
+        self.module_c_temperature = int.from_bytes(self.bus.messages['0x0A0'].data[5] +
+                                              self.bus.messages['0x0A0'].data[4], byteorder='big')
+        self.gate_driver_board_temperature = int.from_bytes(self.bus.messages['0x0A0'].data[7] +
+                                              self.bus.messages['0x0A0'].data[7], byteorder='big')              

--- a/Pidaq/Lib/dts_manager/dts_manager.py
+++ b/Pidaq/Lib/dts_manager/dts_manager.py
@@ -1,9 +1,27 @@
 
 
+from can_manager import can_manager
+
+
 class DTSManager:
 
-    def __init__(self):
-        pass
+    def __init__(self, bus_name: str):
+        self.bus = can_manager.CanManager(bus_name)
 
     def configure_motor(self, configuration: dict) -> None:
-        pass
+        # Extract commands from dict
+        torque_command = int(configuration['torque']).to_bytes(2, 'big')
+        speed_command = int(configuration['speed']).to_bytes(2, 'big')
+        direction_command = int(configuration['direction']).to_bytes(1, 'big')
+        inverter_enable = int(configuration['inverterEnable'])
+        inverter_discharge = int(configuration['inverterDischarge'])
+        speed_mode_enable = int(configuration['speedModeEnable'])
+        mode = ((int(speed_mode_enable) << 2) +
+                (int(inverter_discharge) << 1) + (int(inverter_enable) << 0)).to_bytes(1, 'big')
+        commanded_torque_limit = int(
+            configuration['commandedTorqueLimit']).to_bytes(2, 'big')
+
+        # Create 8 Byte message
+        command_list = bytes(torque_command, speed_command,
+                             direction_command, mode, commanded_torque_limit)
+        self.bus.send_message(192, command_list)

--- a/Pidaq/Lib/dts_manager/dts_manager.py
+++ b/Pidaq/Lib/dts_manager/dts_manager.py
@@ -91,6 +91,8 @@ class DTSTelemetry():
                 self.bus.messages['0xa2'].data[0:2], byteorder='little', signed=True) / 10
             self.rtd_5_temperature = int.from_bytes(
                 self.bus.messages['0xa2'].data[2:4], byteorder='little', signed=True) / 10
+            self.motor_temperature = int.from_bytes(
+                self.bus.messages['0xa2'].data[4:6], byteorder='little', signed=True) / 10
 
     def convert_low_voltages(self) -> None:
         if self.bus.messages['0xa3'].data:

--- a/Pidaq/Lib/dts_manager/dts_manager.py
+++ b/Pidaq/Lib/dts_manager/dts_manager.py
@@ -3,22 +3,58 @@ from enum import Enum
 from can_manager import can_manager
 
 
+class InverterMode(Enum):
+    Torque = 0
+    Speed = 1
+
+
+class InverterDirection(Enum):
+    Reverse = 0
+    Forward = 1
+
+
+class InverterEnable(Enum):
+    Inverter_Off = 0
+    Inverter_On = 1
+
+
+class InverterDischarge(Enum):
+    Disable = 0
+    Enable = 1
+
+
+class MotorConfig():
+    def __init__(self, command: float, direction: InverterDirection, enable: InverterEnable,
+                 discharge: InverterDischarge, mode: InverterMode, commanded_torque_limit: float = 0):
+        self.torque_command = command if mode == InverterMode.Torque else 0
+        self.speed_command = command if mode == InverterMode.Speed else 0
+        self.direction = direction.value
+        self.inverter_enable = enable.value
+        self.inverter_discharge = discharge.value
+        self.mode = mode.value
+        self.commanded_torque_limit = commanded_torque_limit
+
+
 class DTSControl():
 
     def __init__(self, bus: can_manager.CanManager):
         self.bus = bus
 
     def configure_motor(self, configuration: MotorConfig) -> None:
-        self.torque_command = int(configuration.torque_command * 10).to_bytes(2, 'little')
+        self.torque_command = int(
+            configuration.torque_command * 10).to_bytes(2, 'little')
         # Extract commands from dict
-        self.speed_command = int(configuration.speed_command * 10).to_bytes(2, 'little')
-        self.direction_command = int(configuration.direction).to_bytes(1, 'little')
+        self.speed_command = int(
+            configuration.speed_command * 10).to_bytes(2, 'little')
+        self.direction_command = int(
+            configuration.direction).to_bytes(1, 'little')
         self.inverter_enable = int(configuration.inverter_enable)
         self.inverter_discharge = int(configuration.inverter_discharge)
         self.speed_mode_enable = int(configuration.mode)
         self.mode = ((int(self.speed_mode_enable) << 2) +
                      (int(self.inverter_discharge) << 1) + (int(self.inverter_enable) << 0)).to_bytes(1, 'little')
-        self.commanded_torque_limit = int(configuration.commanded_torque_limit * 10).to_bytes(2, 'little')
+        self.commanded_torque_limit = int(
+            configuration.commanded_torque_limit * 10).to_bytes(2, 'little')
 
     def send_motor_command(self) -> None:
         command_list = self.torque_command + self.speed_command + \
@@ -179,33 +215,6 @@ class DTSTelemetry():
             self.torque_feedback = int.from_bytes(
                 self.bus.messages[172].data[2:4], byteorder='little', signed=True) / 10
 
-class InverterMode(Enum):
-    Torque = 0
-    Speed  = 1
-
-class InverterDirection(Enum):
-    Reverse = 0
-    Forward = 1
-
-class InverterEnable(Enum):
-    Inverter_Off = 0
-    Inverter_On  = 1
-
-class InverterDischarge(Enum):
-    Disable = 0
-    Enable = 1
-
-class MotorConfig():
-    def __init__(self, command: float, direction: InverterDirection, enable: InverterEnable,
-                 discharge: InverterDischarge, mode: InverterMode, commanded_torque_limit: float=0):
-        self.torque_command = command if mode == InverterMode.Torque else 0
-        self.speed_command = command if mode == InverterMode.Speed else 0
-        self.direction = direction.value
-        self.inverter_enable = enable.value
-        self.inverter_discharge = discharge.value
-        self.mode = mode.value
-        self.commanded_torque_limit = commanded_torque_limit
-
 
 if __name__ == "__main__":
     import can
@@ -214,15 +223,8 @@ if __name__ == "__main__":
     telemetry = DTSTelemetry(bus)
     telemetry.bus.read_message_config('dts', 'message_config.json')
 
-    motorConfiguration = {
-        'torque': 2000,
-        'speed': 0,
-        'direction': 90,
-        'inverterEnable': 1,
-        'inverterDischarge': 0,
-        'speedModeEnable': 0,
-        'commandedTorqueLimit': 5000
-    }
+    motorConfiguration = MotorConfig(200, InverterDirection.Forward, InverterEnable.Inverter_On,
+                                     InverterDischarge.Enable, InverterMode.Torque, 400)
 
     control.configure_motor(motorConfiguration)
     while True:

--- a/Pidaq/Lib/dts_manager/dts_manager.py
+++ b/Pidaq/Lib/dts_manager/dts_manager.py
@@ -43,261 +43,337 @@ class MotorConfig():
                                         torque limit from EEPROM
     '''
 
-    def __init__(self, command: float, direction: InverterDirection, enable: InverterEnable,
-                 discharge: InverterDischarge, mode: InverterMode, commanded_torque_limit: float = 0):
-        self.torque_command = command if mode == InverterMode.Torque else 0
-        self.speed_command = command if mode == InverterMode.Speed else 0
+    def __init__(self, command=0.0, direction=InverterDirection.Forward, enable=InverterEnable.Inverter_Off,
+                 discharge=InverterDischarge.Disable, mode=InverterMode.Torque, commanded_torque_limit=0.0):
+        self.torque_command = command if mode == InverterMode.Torque else 0.0
+        self.speed_command = command if mode == InverterMode.Speed else 0.0
         self.direction = direction.value
         self.inverter_enable = enable.value
         self.inverter_discharge = discharge.value
         self.mode = mode.value
         self.commanded_torque_limit = commanded_torque_limit
 
-
-class DTSControl():
-    ''' Handles control aspects of DTS motor/inverter
-
-    Fields:
-        bus (can_manager.CanManager): instance of CanManager to communicate with Can bus
-        torque_command (int)
-        speed_command (int)
-        direction_command (int)
-        inverter_enable (int)
-        inverter_discharge (int)
-        speed_mode_enable (int)
-        mode (int)
-        commanded_torque_limit (int)
-
-    Methods:
-        configure_motor(self, configuration: MotorConfig) -> None:
-            When given a MotorConfig object, this method reads all the properties,
-            converts them to bytes which can then be sent in the command message
-
-        send_motor_command(self):
-            Sends motor command over the can bus with the correct message ID to be interpreted
-            by the DTS inverter
-    '''
-
+class DTS():
     def __init__(self, bus: can_manager.CanManager):
-        self.bus = bus
+        self.control = DTS.DTSControl(bus)
+        self.telemetry = DTS.DTSTelemetry(bus)
+        # Add state here if necessary in future
 
-    def configure_motor(self, configuration: MotorConfig) -> None:
-        ''' Configures the motor configuration message'''
-        self.torque_command = int(
-            configuration.torque_command * 10).to_bytes(2, 'little')
-        # Extract commands from dict
-        self.speed_command = int(
-            configuration.speed_command * 10).to_bytes(2, 'little')
-        self.direction_command = int(
-            configuration.direction).to_bytes(1, 'little')
-        self.inverter_enable = int(configuration.inverter_enable)
-        self.inverter_discharge = int(configuration.inverter_discharge)
-        self.speed_mode_enable = int(configuration.mode)
-        self.mode = ((int(self.speed_mode_enable) << 2) +
-                     (int(self.inverter_discharge) << 1) + (int(self.inverter_enable) << 0)).to_bytes(1, 'little')
-        self.commanded_torque_limit = int(
-            configuration.commanded_torque_limit * 10).to_bytes(2, 'little')
+    class DTSControl():
+        ''' Handles control aspects of DTS motor/inverter
 
-    def send_motor_command(self) -> None:
-        ''' Send motor command over the can bus
+        Fields:
+            bus (can_manager.CanManager): instance of CanManager to communicate with Can bus
+            torque_command (int)
+            speed_command (int)
+            direction_command (int)
+            inverter_enable (int)
+            inverter_discharge (int)
+            speed_mode_enable (int)
+            mode (int)
+            commanded_torque_limit (int)
 
-        Note: This method should not be called until after the configure_motor method has been called
-              at least once to configure a command message.
+        Methods:
+            configure_motor(self, configuration=MotorConfig()) -> None:
+                When given a MotorConfig object, this method reads all the properties,
+                converts them to bytes which can then be sent in the command message
+
+            send_motor_command(self):
+                Sends motor command over the can bus with the correct message ID to be interpreted
+                by the DTS inverter
         '''
-        command_list = self.torque_command + self.speed_command + \
-            self.direction_command + self.mode + self.commanded_torque_limit
-        self.bus.send_message(192, command_list)
 
+        def __init__(self, bus: can_manager.CanManager):
+            self.bus = bus
 
-class DTSTelemetry():
-    ''' Handles the telemetry and data acquisition from the DTS motor/inverter
+            # Default can offset is 160, can be changed in EEPROM
+            self.message_offset = 160
+            self.command_id = self.message_offset + 32
 
-    Fields:
-        See __init__ for fields, all possible data fields are stored within the class
+        def configure_motor(self, configuration=MotorConfig()) -> None:
+            ''' Configures the motor configuration message'''
+            self.torque_command = int(
+                configuration.torque_command * 10).to_bytes(2, 'little')
+            # Extract commands from dict
+            self.speed_command = int(
+                configuration.speed_command * 10).to_bytes(2, 'little')
+            self.direction_command = int(
+                configuration.direction).to_bytes(1, 'little')
+            self.inverter_enable = int(configuration.inverter_enable)
+            self.inverter_discharge = int(configuration.inverter_discharge)
+            self.speed_mode_enable = int(configuration.mode)
+            self.mode = ((int(self.speed_mode_enable) << 2) +
+                        (int(self.inverter_discharge) << 1) + (int(self.inverter_enable) << 0)).to_bytes(1, 'little')
+            self.commanded_torque_limit = int(
+                configuration.commanded_torque_limit * 10).to_bytes(2, 'little')
 
-    Methods:
-    Note: each method converts a different set of data, depending on the conversion factor
-          defined in the CAN message format manual for the inverter
+        def send_motor_command_config(self) -> None:
+            ''' Send motor command over the can bus
 
-        convert_angles(self)
-        convert_booleans(self)
-        convert_currents(self)
-        convert_high_voltages(self)
-        convert_low_voltages(self)
-        convert_torques(self)
-        convert_temperatures(self)
-    '''
+            Note: This method should not be called until after the configure_motor method has been called
+                at least once to configure a command message.
+            '''
+            command_list = self.torque_command + self.speed_command + \
+                self.direction_command + self.mode + self.commanded_torque_limit
+            self.bus.send_message(self.command_id, command_list)
 
-    def __init__(self, bus: can_manager.CanManager):
-        ''' Takes reference to a CanManager instance to be used for receiving can messages'''
-        self.bus = bus
-        self.module_a_temperature = None
-        self.module_b_temperature = None
-        self.module_c_temperature = None
-        self.gate_driver_board_temperature = None
-        self.control_board_temperature = None
-        self.rtd_1_temperature = None
-        self.rtd_2_temperature = None
-        self.rtd_3_temperature = None
-        self.rtd_4_temperature = None
-        self.rtd_5_temperature = None
-        self.analog_input_1 = None
-        self.analog_input_2 = None
-        self.analog_input_3 = None
-        self.analog_input_4 = None
-        self.dc_bus_voltage = None
-        self.output_voltage = None
-        self.vab_vd_voltage = None
-        self.vbc_vq_voltage = None
-        self.motor_angle = None
-        self.delta_filter_resolved = None
-        self.one_five_voltage_ref = None
-        self.two_five_voltage_ref = None
-        self.five_voltage_ref = None
-        self.twelve_system_voltage = None
-        self.digital_input_1 = None
-        self.digital_input_2 = None
-        self.digital_input_3 = None
-        self.digital_input_4 = None
-        self.digital_input_5 = None
-        self.digital_input_6 = None
-        self.digital_input_7 = None
-        self.digital_input_8 = None
-        self.id_feedback = None
-        self.iq_feedback = None
-        self.torque_shudder = None
-        self.commanded_torque = None
+        def send_motor_command(self, command, mode=InverterMode.Torque):
+            speed_command = int(command if mode == InverterMode.Speed else 0).to_bytes(2, 'little')
+            torque_commmand = (command if mode == InverterMode.Torque else 0).to_bytes(2, 'little')
+            mode = ((int(self.mode.value) << 2) +
+                   (int(self.inverter_discharge) << 1) + (int(self.inverter_enable) << 0)).to_bytes(1, 'little')
+            command_list = torque_commmand + speed_command + \
+                self.direction_command + mode + self.commanded_torque_limit
+            self.bus.send_message(self.command_id, command_list)
 
-    def convert_temperatures(self) -> None:
-        if self.bus.messages[160].data:
-            self.module_a_temperature = int.from_bytes(
-                self.bus.messages[160].data[0:2], byteorder='little', signed=True) / 10
-            self.module_b_temperature = int.from_bytes(
-                self.bus.messages[160].data[2:4], byteorder='little', signed=True) / 10
-            self.module_c_temperature = int.from_bytes(
-                self.bus.messages[160].data[4:6], byteorder='little', signed=True) / 10
-            self.gate_driver_board_temperature = int.from_bytes(
-                self.bus.messages[160].data[6:], byteorder='little', signed=True) / 10
-        if self.bus.messages[161].data:
-            self.control_board_temperature = int.from_bytes(
-                self.bus.messages[161].data[0:2], byteorder='little', signed=True) / 10
-            self.rtd_1_temperature = int.from_bytes(
-                self.bus.messages[161].data[2:4], byteorder='little', signed=True) / 10
-            self.rtd_2_temperature = int.from_bytes(
-                self.bus.messages[161].data[4:6], byteorder='little', signed=True) / 10
-            self.rtd_3_temperature = int.from_bytes(
-                self.bus.messages[161].data[6:], byteorder='little', signed=True) / 10
-        if self.bus.messages[162].data:
-            self.rtd_4_temperature = int.from_bytes(
-                self.bus.messages[162].data[0:2], byteorder='little', signed=True) / 10
-            self.rtd_5_temperature = int.from_bytes(
-                self.bus.messages[162].data[2:4], byteorder='little', signed=True) / 10
-            self.motor_temperature = int.from_bytes(
-                self.bus.messages[162].data[4:6], byteorder='little', signed=True) / 10
+    class DTSTelemetry():
+        ''' Handles the telemetry and data acquisition from the DTS motor/inverter
 
-    def convert_low_voltages(self) -> None:
-        if self.bus.messages[163].data:
-            self.analog_input_1 = int.from_bytes(
-                self.bus.messages[163].data[0:2], byteorder='little', signed=True) / 100
-            self.analog_input_2 = int.from_bytes(
-                self.bus.messages[163].data[2:4], byteorder='little', signed=True) / 100
-            self.analog_input_3 = int.from_bytes(
-                self.bus.messages[163].data[4:6], byteorder='little', signed=True) / 100
-            self.analog_input_4 = int.from_bytes(
-                self.bus.messages[163].data[6:], byteorder='little', signed=True) / 100
-        if self.bus.messages[169].data:
-            self.one_five_voltage_ref = int.from_bytes(
-                self.bus.messages[169].data[0:2], byteorder='little', signed=True) / 100
-            self.two_five_voltage_ref = int.from_bytes(
-                self.bus.messages[169].data[2:4], byteorder='little', signed=True) / 100
-            self.five_voltage_ref = int.from_bytes(
-                self.bus.messages[169].data[4:6], byteorder='little', signed=True) / 100
-            self.twelve_system_voltage = int.from_bytes(
-                self.bus.messages[169].data[6:], byteorder='little', signed=True) / 100
+        Fields:
+            See __init__ for fields, all possible data fields are stored within the class
 
-    def convert_high_voltages(self) -> None:
-        if self.bus.messages[167].data:
-            self.dc_bus_voltage = int.from_bytes(
-                self.bus.messages[167].data[0:2], byteorder='little', signed=True) / 10
-            self.output_voltage = int.from_bytes(
-                self.bus.messages[167].data[2:4], byteorder='little', signed=True) / 10
-            self.vab_vd_voltage = int.from_bytes(
-                self.bus.messages[167].data[4:6], byteorder='little', signed=True) / 10
-            self.vbc_vq_voltage = int.from_bytes(
-                self.bus.messages[167].data[6:], byteorder='little', signed=True) / 10
+        Methods:
+        Note: each method converts a different set of data, depending on the conversion factor
+            defined in the CAN message format manual for the inverter
 
-    def convert_currents(self) -> None:
-        if self.bus.messages[166].data:
-            self.phase_a_current = int.from_bytes(
-                self.bus.messages[166].data[0:2], byteorder='little', signed=True) / 10
-            self.phase_b_current = int.from_bytes(
-                self.bus.messages[166].data[2:4], byteorder='little', signed=True) / 10
-            self.phase_c_current = int.from_bytes(
-                self.bus.messages[166].data[4:6], byteorder='little', signed=True) / 10
-            self.dc_bus_current = int.from_bytes(
-                self.bus.messages[166].data[6:], byteorder='little', signed=True) / 10
-        if self.bus.messages[168].data:
-            self.id_feedback = int.from_bytes(
-                self.bus.messages[168].data[4:6], byteorder='little', signed=True) / 10
-            self.iq_feedback = int.from_bytes(
-                self.bus.messages[168].data[6:], byteorder='little', signed=True) / 10
+            convert_angles(self)
+            convert_booleans(self)
+            convert_currents(self)
+            convert_high_voltages(self)
+            convert_low_voltages(self)
+            convert_torques(self)
+            convert_temperatures(self)
+        '''
 
-    def convert_angles(self) -> None:
-        if self.bus.messages[165].data:
-            self.motor_angle = int.from_bytes(
-                self.bus.messages[165].data[0:2], byteorder='little', signed=True) / 10
-            self.delta_filter_resolved = int.from_bytes(
-                self.bus.messages[165].data[6:], byteorder='little', signed=True) / 10
+        def __init__(self, bus: can_manager.CanManager):
+            ''' Takes reference to a CanManager instance to be used for receiving can messages'''
+            self.bus = bus
+            self.module_a_temperature = None
+            self.module_b_temperature = None
+            self.module_c_temperature = None
+            self.gate_driver_board_temperature = None
+            self.control_board_temperature = None
+            self.rtd_1_temperature = None
+            self.rtd_2_temperature = None
+            self.rtd_3_temperature = None
+            self.rtd_4_temperature = None
+            self.rtd_5_temperature = None
+            self.analog_input_1 = None
+            self.analog_input_2 = None
+            self.analog_input_3 = None
+            self.analog_input_4 = None
+            self.dc_bus_voltage = None
+            self.output_voltage = None
+            self.vab_vd_voltage = None
+            self.vbc_vq_voltage = None
+            self.motor_angle = None
+            self.delta_filter_resolved = None
+            self.one_five_voltage_ref = None
+            self.two_five_voltage_ref = None
+            self.five_voltage_ref = None
+            self.twelve_system_voltage = None
+            self.digital_input_1 = None
+            self.digital_input_2 = None
+            self.digital_input_3 = None
+            self.digital_input_4 = None
+            self.digital_input_5 = None
+            self.digital_input_6 = None
+            self.digital_input_7 = None
+            self.digital_input_8 = None
+            self.id_feedback = None
+            self.iq_feedback = None
+            self.torque_shudder = None
+            self.commanded_torque = None
+            
+            # Default can offset is 160, can be changed in EEPROM
+            self.default_can_offset = 160
+            self.temp1_id = self.default_can_offset
+            self.temp2_id = self.default_can_offset + 1
+            self.temp3_id = self.default_can_offset + 2
+            self.analog_inputs_id = self.default_can_offset + 3
+            self.digital_input_status_id = self.default_can_offset + 4
+            self.motor_position_id = self.default_can_offset + 5
+            self.current_info_id = self.default_can_offset + 6
+            self.voltage_info_id = self.default_can_offset + 7
+            self.flux_info_id = self.default_can_offset + 8
+            self.internal_voltages_id = self.default_can_offset + 9
+            self.internal_states_id = self.default_can_offset + 10
+            self.fault_codes_id = self.default_can_offset + 11
+            self.torque_timer_id = self.default_can_offset + 12
+            self.modulation_index_id = self.default_can_offset + 13
+        
+        def get_temp1_data(self):
+            return self.bus.messages[self.temp1_id].data
+        
+        def get_temp2_data(self):
+            return self.bus.messages[self.temp2_id].data
+        
+        def get_temp3_data(self):
+            return self.bus.messages[self.temp3_id].data
 
-    def convert_booleans(self) -> None:
-        BIT_0 = 1 << 0
-        BIT_1 = 1 << 1
-        BIT_2 = 1 << 2
-        BIT_3 = 1 << 3
-        BIT_4 = 1 << 4
-        BIT_5 = 1 << 5
-        BIT_6 = 1 << 6
-        BIT_7 = 1 << 7
-        if self.bus.messages[164]:
-            digital_input_status = int.from_bytes(
-                self.bus.messages[164].data[0:], byteorder='little', signed=False)
-            self.digital_input_1 = bool(digital_input_status & BIT_0)
-            self.digital_input_2 = bool(digital_input_status & BIT_1)
-            self.digital_input_3 = bool(digital_input_status & BIT_2)
-            self.digital_input_4 = bool(digital_input_status & BIT_3)
-            self.digital_input_5 = bool(digital_input_status & BIT_4)
-            self.digital_input_6 = bool(digital_input_status & BIT_5)
-            self.digital_input_7 = bool(digital_input_status & BIT_6)
-            self.digital_input_8 = bool(digital_input_status & BIT_7)
+        def get_analog_input_voltages_data(self):
+            return self.bus.messages[self.analog_inputs_id].data
+        
+        def get_digital_input_status_data(self):
+            return self.bus.messages[self.digital_input_status_id].data
+        
+        def get_motor_position_data(self):
+            return self.bus.messages[self.motor_position_id].data
 
-    def convert_torques(self) -> None:
-        if self.bus.messages[162].data:
-            self.torque_shudder = int.from_bytes(
-                self.bus.messages[162].data[6:], byteorder='little', signed=True) / 10
-        if self.bus.messages[172].data:
-            self.commanded_torque = int.from_bytes(
-                self.bus.messages[172].data[0:2], byteorder='little', signed=True) / 10
-            self.torque_feedback = int.from_bytes(
-                self.bus.messages[172].data[2:4], byteorder='little', signed=True) / 10
+        def get_current_data(self):
+            return self.bus.messages[self.current_info_id].data
+
+        def get_voltage_data(self):
+            return self.bus.messages[self.voltage_info_id].data
+
+        def get_flux_data(self):
+            return self.bus.messages[self.flux_info_id].data
+
+        def get_internal_voltages_data(self):
+            return self.bus.messages[self.internal_voltages_id].data
+        
+        def get_internal_states_data(self):
+            return self.bus.messages[self.internal_states_id].data
+
+        def get_faults_data(self):
+            return self.bus.messages[self.fault_codes_id].data
+
+        def get_torque_timer_data(self):
+            return self.bus.messages[self.torque_timer_id].data
+        
+        def get_modulation_index_data(self):
+            return self.bus.messages[self.modulation_index_id].data
+
+        def convert_temperatures(self) -> None:
+            if self.get_temp1_data():
+                self.module_a_temperature = int.from_bytes(
+                    self.get_temp1_data()[0:2], byteorder='little', signed=True) / 10
+                self.module_b_temperature = int.from_bytes(
+                    self.get_temp1_data()[2:4], byteorder='little', signed=True) / 10
+                self.module_c_temperature = int.from_bytes(
+                    self.get_temp1_data()[4:6], byteorder='little', signed=True) / 10
+                self.gate_driver_board_temperature = int.from_bytes(
+                    self.get_temp1_data()[6:], byteorder='little', signed=True) / 10
+            if self.get_temp2_data():
+                self.control_board_temperature = int.from_bytes(
+                    self.get_temp2_data()[0:2], byteorder='little', signed=True) / 10
+                self.rtd_1_temperature = int.from_bytes(
+                    self.get_temp2_data()[2:4], byteorder='little', signed=True) / 10
+                self.rtd_2_temperature = int.from_bytes(
+                    self.get_temp2_data()[4:6], byteorder='little', signed=True) / 10
+                self.rtd_3_temperature = int.from_bytes(
+                    self.get_temp2_data()[6:], byteorder='little', signed=True) / 10
+            if self.get_temp3_data():
+                self.rtd_4_temperature = int.from_bytes(
+                    self.get_temp3_data()[0:2], byteorder='little', signed=True) / 10
+                self.rtd_5_temperature = int.from_bytes(
+                    self.get_temp3_data()[2:4], byteorder='little', signed=True) / 10
+                self.motor_temperature = int.from_bytes(
+                    self.get_temp3_data()[4:6], byteorder='little', signed=True) / 10
+
+        def convert_low_voltages(self) -> None:
+            if self.get_analog_input_voltages_data():
+                self.analog_input_1 = int.from_bytes(
+                    self.get_analog_input_voltages_data()[0:2], byteorder='little', signed=True) / 100
+                self.analog_input_2 = int.from_bytes(
+                    self.get_analog_input_voltages_data()[2:4], byteorder='little', signed=True) / 100
+                self.analog_input_3 = int.from_bytes(
+                    self.get_analog_input_voltages_data()[4:6], byteorder='little', signed=True) / 100
+                self.analog_input_4 = int.from_bytes(
+                    self.get_analog_input_voltages_data()[6:], byteorder='little', signed=True) / 100
+            if self.get_internal_voltages_data():
+                self.one_five_voltage_ref = int.from_bytes(
+                    self.get_internal_voltages_data()[0:2], byteorder='little', signed=True) / 100
+                self.two_five_voltage_ref = int.from_bytes(
+                    self.get_internal_voltages_data()[2:4], byteorder='little', signed=True) / 100
+                self.five_voltage_ref = int.from_bytes(
+                    self.get_internal_voltages_data()[4:6], byteorder='little', signed=True) / 100
+                self.twelve_system_voltage = int.from_bytes(
+                    self.get_internal_voltages_data()[6:], byteorder='little', signed=True) / 100
+
+        def convert_high_voltages(self) -> None:
+            if self.get_voltage_data():
+                self.dc_bus_voltage = int.from_bytes(
+                    self.get_voltage_data()[0:2], byteorder='little', signed=True) / 10
+                self.output_voltage = int.from_bytes(
+                    self.get_voltage_data()[2:4], byteorder='little', signed=True) / 10
+                self.vab_vd_voltage = int.from_bytes(
+                    self.get_voltage_data()[4:6], byteorder='little', signed=True) / 10
+                self.vbc_vq_voltage = int.from_bytes(
+                    self.get_voltage_data()[6:], byteorder='little', signed=True) / 10
+
+        def convert_currents(self) -> None:
+            if self.get_current_data():
+                self.phase_a_current = int.from_bytes(
+                    self.get_current_data()[0:2], byteorder='little', signed=True) / 10
+                self.phase_b_current = int.from_bytes(
+                    self.get_current_data()[2:4], byteorder='little', signed=True) / 10
+                self.phase_c_current = int.from_bytes(
+                    self.get_current_data()[4:6], byteorder='little', signed=True) / 10
+                self.dc_bus_current = int.from_bytes(
+                    self.get_current_data()[6:], byteorder='little', signed=True) / 10
+            if self.get_flux_data():
+                self.id_feedback = int.from_bytes(
+                    self.get_flux_data()[4:6], byteorder='little', signed=True) / 10
+                self.iq_feedback = int.from_bytes(
+                    self.get_flux_data()[6:], byteorder='little', signed=True) / 10
+
+        def convert_angles(self) -> None:
+            if self.get_motor_position_data():
+                self.motor_angle = int.from_bytes(
+                    self.get_motor_position_data(), byteorder='little', signed=True) / 10
+                self.delta_filter_resolved = int.from_bytes(
+                    self.get_motor_position_data(), byteorder='little', signed=True) / 10
+
+        def convert_booleans(self) -> None:
+            BIT_0 = 1 << 0
+            BIT_1 = 1 << 1
+            BIT_2 = 1 << 2
+            BIT_3 = 1 << 3
+            BIT_4 = 1 << 4
+            BIT_5 = 1 << 5
+            BIT_6 = 1 << 6
+            BIT_7 = 1 << 7
+            if self.get_digital_input_status_data():
+                digital_input_status = int.from_bytes(
+                    self.get_digital_input_status_data()[0:], byteorder='little', signed=False)
+                self.digital_input_1 = bool(digital_input_status & BIT_0)
+                self.digital_input_2 = bool(digital_input_status & BIT_1)
+                self.digital_input_3 = bool(digital_input_status & BIT_2)
+                self.digital_input_4 = bool(digital_input_status & BIT_3)
+                self.digital_input_5 = bool(digital_input_status & BIT_4)
+                self.digital_input_6 = bool(digital_input_status & BIT_5)
+                self.digital_input_7 = bool(digital_input_status & BIT_6)
+                self.digital_input_8 = bool(digital_input_status & BIT_7)
+
+        def convert_torques(self) -> None:
+            if self.get_temp3_data():
+                self.torque_shudder = int.from_bytes(
+                    self.get_temp3_data()[6:], byteorder='little', signed=True) / 10
+            if self.get_torque_timer_data():
+                self.commanded_torque = int.from_bytes(
+                    self.get_torque_timer_data()[0:2], byteorder='little', signed=True) / 10
+                self.torque_feedback = int.from_bytes(
+                    self.get_torque_timer_data()[2:4], byteorder='little', signed=True) / 10
 
 
 if __name__ == "__main__":
-    import can
+    import random
     bus = can_manager.CanManager('vcan0')
-    control = DTSControl(bus)
-    telemetry = DTSTelemetry(bus)
+    dts = DTS(bus)
     bus.read_message_config('dts', 'message_config.json')
 
     motorConfiguration = MotorConfig(200, InverterDirection.Forward, InverterEnable.Inverter_On,
                                      InverterDischarge.Enable, InverterMode.Torque, 400)
 
-    control.configure_motor(motorConfiguration)
+    dts.control.configure_motor(motorConfiguration)
+    dts.control.send_motor_command_config()
     while True:
-        control.send_motor_command()
-        current_message = telemetry.bus.read_bus()
-        telemetry.bus.assign_message_data(current_message)
-        telemetry.convert_low_voltages()
-        print(telemetry.one_five_voltage_ref)
-        print(telemetry.two_five_voltage_ref)
-        print(telemetry.five_voltage_ref)
-        print(telemetry.twelve_system_voltage)
+        current_message = dts.telemetry.bus.read_bus()
+        dts.telemetry.bus.assign_message_data(current_message)
+        dts.telemetry.convert_low_voltages()
+        print(dts.telemetry.one_five_voltage_ref)
+        print(dts.telemetry.two_five_voltage_ref)
+        print(dts.telemetry.five_voltage_ref)
+        print(dts.telemetry.twelve_system_voltage)
+        dts.control.send_motor_command(random.randrange(190, 220), InverterMode.Torque)

--- a/Pidaq/Lib/dts_manager/dts_manager.py
+++ b/Pidaq/Lib/dts_manager/dts_manager.py
@@ -53,6 +53,7 @@ class MotorConfig():
         self.mode = mode.value
         self.commanded_torque_limit = commanded_torque_limit
 
+
 class DTS():
     def __init__(self, bus: can_manager.CanManager):
         self.control = DTS.DTSControl(bus)
@@ -103,7 +104,7 @@ class DTS():
             self.inverter_discharge = int(configuration.inverter_discharge)
             self.speed_mode_enable = int(configuration.mode)
             self.mode = ((int(self.speed_mode_enable) << 2) +
-                        (int(self.inverter_discharge) << 1) + (int(self.inverter_enable) << 0)).to_bytes(1, 'little')
+                         (int(self.inverter_discharge) << 1) + (int(self.inverter_enable) << 0)).to_bytes(1, 'little')
             self.commanded_torque_limit = int(
                 configuration.commanded_torque_limit * 10).to_bytes(2, 'little')
 
@@ -118,10 +119,12 @@ class DTS():
             self.bus.send_message(self.command_id, command_list)
 
         def send_motor_command(self, command, mode=InverterMode.Torque):
-            speed_command = int(command if mode == InverterMode.Speed else 0).to_bytes(2, 'little')
-            torque_commmand = (command if mode == InverterMode.Torque else 0).to_bytes(2, 'little')
-            mode = ((int(self.mode.value) << 2) +
-                   (int(self.inverter_discharge) << 1) + (int(self.inverter_enable) << 0)).to_bytes(1, 'little')
+            speed_command = int(
+                command * 10 if mode == InverterMode.Speed else 0).to_bytes(2, 'little')
+            torque_commmand = (
+                command * 10 if mode == InverterMode.Torque else 0).to_bytes(2, 'little')
+            mode = ((int(mode.value) << 2) +
+                    (int(self.inverter_discharge) << 1) + (int(self.inverter_enable) << 0)).to_bytes(1, 'little')
             command_list = torque_commmand + speed_command + \
                 self.direction_command + mode + self.commanded_torque_limit
             self.bus.send_message(self.command_id, command_list)
@@ -184,7 +187,7 @@ class DTS():
             self.iq_feedback = None
             self.torque_shudder = None
             self.commanded_torque = None
-            
+
             # Default can offset is 160, can be changed in EEPROM
             self.default_can_offset = 160
             self.temp1_id = self.default_can_offset
@@ -201,22 +204,22 @@ class DTS():
             self.fault_codes_id = self.default_can_offset + 11
             self.torque_timer_id = self.default_can_offset + 12
             self.modulation_index_id = self.default_can_offset + 13
-        
+
         def get_temp1_data(self):
             return self.bus.messages[self.temp1_id].data
-        
+
         def get_temp2_data(self):
             return self.bus.messages[self.temp2_id].data
-        
+
         def get_temp3_data(self):
             return self.bus.messages[self.temp3_id].data
 
         def get_analog_input_voltages_data(self):
             return self.bus.messages[self.analog_inputs_id].data
-        
+
         def get_digital_input_status_data(self):
             return self.bus.messages[self.digital_input_status_id].data
-        
+
         def get_motor_position_data(self):
             return self.bus.messages[self.motor_position_id].data
 
@@ -231,7 +234,7 @@ class DTS():
 
         def get_internal_voltages_data(self):
             return self.bus.messages[self.internal_voltages_id].data
-        
+
         def get_internal_states_data(self):
             return self.bus.messages[self.internal_states_id].data
 
@@ -240,7 +243,7 @@ class DTS():
 
         def get_torque_timer_data(self):
             return self.bus.messages[self.torque_timer_id].data
-        
+
         def get_modulation_index_data(self):
             return self.bus.messages[self.modulation_index_id].data
 
@@ -376,4 +379,5 @@ if __name__ == "__main__":
         print(dts.telemetry.two_five_voltage_ref)
         print(dts.telemetry.five_voltage_ref)
         print(dts.telemetry.twelve_system_voltage)
-        dts.control.send_motor_command(random.randrange(190, 220), InverterMode.Torque)
+        dts.control.send_motor_command(
+            random.randrange(190, 220), InverterMode.Torque)

--- a/Pidaq/Lib/dts_manager/dts_manager.py
+++ b/Pidaq/Lib/dts_manager/dts_manager.py
@@ -1,5 +1,3 @@
-
-
 from can_manager import can_manager
 
 
@@ -7,6 +5,16 @@ class DTSManager:
 
     def __init__(self, bus_name: str):
         self.bus = can_manager.CanManager(bus_name)
+        self.module_a_temperature = None
+        self.module_b_temperature = None
+        self.module_c_temperature = None
+        self.gate_driver_board_temperature = None
+        self.control_board_temperature = None
+        self.rtd_1_temperature = None
+        self.rtd_2_temperature = None
+        self.rtd_3_temperature = None
+        self.rtd_4_temperature = None
+        self.rtd_5_temperature = None
 
     def configure_motor(self, configuration: dict) -> None:
         # Extract commands from dict
@@ -23,16 +31,58 @@ class DTSManager:
             configuration['commandedTorqueLimit']).to_bytes(2, 'big')
 
     def send_motor_command(self) -> None:
-        command_list = bytes(self.torque_command, self.speed_command,
-                             self.direction_command, self.mode, self.commanded_torque_limit)
+        command_list = self.torque_command + self.speed_command + \
+            self.direction_command + self.mode + self.commanded_torque_limit
         self.bus.send_message(192, command_list)
 
     def convert_temperatures(self) -> None:
-        self.module_a_temperature = int.from_bytes(self.bus.messages['0x0A0'].data[1] +
-                                              self.bus.messages['0x0A0'].data[0], byteorder='big')
-        self.module_b_temperature = int.from_bytes(self.bus.messages['0x0A0'].data[3] +
-                                              self.bus.messages['0x0A0'].data[2], byteorder='big')
-        self.module_c_temperature = int.from_bytes(self.bus.messages['0x0A0'].data[5] +
-                                              self.bus.messages['0x0A0'].data[4], byteorder='big')
-        self.gate_driver_board_temperature = int.from_bytes(self.bus.messages['0x0A0'].data[7] +
-                                              self.bus.messages['0x0A0'].data[7], byteorder='big')              
+        if self.bus.messages['0xa0'].data and self.bus.messages['0xa1'].data and self.bus.messages['0xa2'].data:
+            print(self.bus.messages['0xa0'].data[1])
+            self.module_a_temperature = int.from_bytes(
+                self.bus.messages['0xa0'].data[2:0:-1], byteorder='big') / 10
+            self.module_b_temperature = int.from_bytes(
+                self.bus.messages['0xa0'].data[4:2:-1], byteorder='big') / 10
+            self.module_c_temperature = int.from_bytes(
+                self.bus.messages['0xa0'].data[6:4:-1], byteorder='big') / 10
+            self.gate_driver_board_temperature = int.from_bytes(
+                self.bus.messages['0xa0'].data[:6:-1], byteorder='big') / 10
+            self.control_board_temperature = int.from_bytes(
+                self.bus.messages['0xa1'].data[2:0:-1], byteorder='big') / 10
+            self.rtd_1_temperature = int.from_bytes(
+                self.bus.messages['0xa1'].data[4:2:-1], byteorder='big') / 10
+            self.rtd_2_temperature = int.from_bytes(
+                self.bus.messages['0xa1'].data[6:4:-1], byteorder='big') / 10
+            self.rtd_3_temperature = int.from_bytes(
+                self.bus.messages['0xa1'].data[:6:-1], byteorder='big') / 10
+            self.rtd_4_temperature = int.from_bytes(
+                self.bus.messages['0xa2'].data[2:0:-1], byteorder='big') / 10
+            self.rtd_5_temperature = int.from_bytes(
+                self.bus.messages['0xa2'].data[4:2:-1], byteorder='big') / 10
+
+    def convert_torques(self) -> None:
+        pass
+
+
+if __name__ == "__main__":
+    import can
+    dts = DTSManager('vcan0')
+    dts.bus.read_message_config('dts', 'message_config.json')
+
+    motorConfiguration = {
+        'torque': 2000,
+        'speed': 0,
+        'direction': 90,
+        'inverterEnable': 1,
+        'inverterDischarge': 0,
+        'speedModeEnable': 0,
+        'commandedTorqueLimit': 5000
+    }
+
+    dts.configure_motor(motorConfiguration)
+    while True:
+        dts.send_motor_command()
+        current_message = dts.bus.read_bus()
+        dts.bus.assign_message_data(current_message)
+        dts.convert_temperatures()
+        print(dts.module_a_temperature)
+        print(dts.module_b_temperature)

--- a/Pidaq/Lib/dts_manager/dts_manager.py
+++ b/Pidaq/Lib/dts_manager/dts_manager.py
@@ -122,14 +122,14 @@ class DTS():
 
         def send_motor_command(self, command: float, mode=InverterMode.Torque):
             """ Sends a motor command using existing info plus new speed/torque command and mode
-            
+
             Uses all existing message configuration except for speed/torque command, and mode.
             Can be used to issue subsequent commands after the motor has been configured intially
 
             Args:
                 command (float): New speed/torque command, depending on the mode
                 mode (InverterMode)
-            """ 
+            """
             speed_command = int(
                 command * 10 if mode == InverterMode.Speed else 0).to_bytes(2, 'little')
             torque_commmand = (
@@ -235,46 +235,88 @@ class DTS():
             return self.bus.messages[message_id].conversion_factor
 
         def get_temp1_data(self, start=0, stop=8):
-            return self.bus.messages[self.temp1_id].data[start:stop]
+            if self.bus.messages[self.temp1_id].data:
+                return self.bus.messages[self.temp1_id].data[start:stop]
+            else:
+                return None
 
         def get_temp2_data(self, start=0, stop=8):
-            return self.bus.messages[self.temp2_id].data[start:stop]
+            if self.bus.messages[self.temp2_id].data[start:stop]:
+                return self.bus.messages[self.temp2_id].data[start:stop]
+            else:
+                return None
 
         def get_temp3_data(self, start=0, stop=8):
-            return self.bus.messages[self.temp3_id].data[start:stop]
+            if self.bus.messages[self.temp3_id].data[start:stop]:
+                return self.bus.messages[self.temp3_id].data[start:stop]
+            else:
+                return None
 
         def get_analog_input_voltages_data(self, start=0, stop=8):
-            return self.bus.messages[self.analog_inputs_id].data[start:stop]
+            if self.bus.messages[self.analog_inputs_id].data:
+                return self.bus.messages[self.analog_inputs_id].data[start:stop]
+            else:
+                return None
 
         def get_digital_input_status_data(self, start=0, stop=8):
-            return self.bus.messages[self.digital_input_status_id].data[start:stop]
+            if self.bus.messages[self.digital_input_status_id].data:
+                return self.bus.messages[self.digital_input_status_id].data[start:stop]
+            else:
+                return None
 
         def get_motor_position_data(self, start=0, stop=8):
-            return self.bus.messages[self.motor_position_id].data[start:stop]
+            if self.bus.messages[self.motor_position_id].data:
+                return self.bus.messages[self.motor_position_id].data[start:stop]
+            else:
+                return None
 
         def get_current_data(self, start=0, stop=8):
-            return self.bus.messages[self.current_info_id].data[start:stop]
+            if self.bus.messages[self.current_info_id].data:
+                return self.bus.messages[self.current_info_id].data[start:stop]
+            else:
+                return None
 
         def get_voltage_data(self, start=0, stop=8):
-            return self.bus.messages[self.voltage_info_id].data[start:stop]
+            if self.bus.messages[self.voltage_info_id].data:
+                return self.bus.messages[self.voltage_info_id].data[start:stop]
+            else:
+                return None
 
         def get_flux_data(self, start=0, stop=8):
-            return self.bus.messages[self.flux_info_id].data[start:stop]
+            if self.bus.messages[self.flux_info_id].data:
+                return self.bus.messages[self.flux_info_id].data[start:stop]
+            else:
+                return None
 
         def get_internal_voltages_data(self, start=0, stop=8):
-            return self.bus.messages[self.internal_voltages_id].data[start:stop]
+            if self.bus.messages[self.internal_voltages_id].data:
+                return self.bus.messages[self.internal_voltages_id].data[start:stop]
+            else:
+                return None
 
         def get_internal_states_data(self, start=0, stop=8):
-            return self.bus.messages[self.internal_states_id].data[start:stop]
+            if self.bus.messages[self.internal_states_id].data:
+                return self.bus.messages[self.internal_states_id].data[start:stop]
+            else:
+                return None
 
         def get_faults_data(self, start=0, stop=8):
-            return self.bus.messages[self.fault_codes_id].data[start:stop]
+            if self.bus.messages[self.fault_codes_id].data:
+                return self.bus.messages[self.fault_codes_id].data[start:stop]
+            else:
+                return None
 
         def get_torque_timer_data(self, start=0, stop=8):
-            return self.bus.messages[self.torque_timer_id].data[start:stop]
+            if self.bus.messages[self.torque_timer_id].data:
+                return self.bus.messages[self.torque_timer_id].data[start:stop]
+            else:
+                return None
 
         def get_modulation_index_data(self, start=0, stop=8):
-            return self.bus.messages[self.modulation_index_id].data[start:stop]
+            if self.bus.messages[self.modulation_index_id].data:
+                return self.bus.messages[self.modulation_index_id].data[start:stop]
+            else:
+                return None
 
         def update_temperatures(self) -> None:
             if self.get_temp1_data():
@@ -341,7 +383,7 @@ class DTS():
                 self.phase_b_current = int.from_bytes(
                     self.get_current_data(2, 4), byteorder='little', signed=True) / self.get_conversion_factor(self.current_info_id)
                 self.phase_c_current = int.from_bytes(
-                    self.get_current_data(4,6), byteorder='little', signed=True) / self.get_conversion_factor(self.current_info_id)
+                    self.get_current_data(4, 6), byteorder='little', signed=True) / self.get_conversion_factor(self.current_info_id)
                 self.dc_bus_current = int.from_bytes(
                     self.get_current_data(6, 8), byteorder='little', signed=True) / self.get_conversion_factor(self.current_info_id)
             if self.get_flux_data():
@@ -403,7 +445,7 @@ if __name__ == "__main__":
     while True:
         current_message = dts.telemetry.bus.read_bus()
         dts.telemetry.bus.assign_message_data(current_message)
-        dts.telemetry.convert_low_voltages()
+        dts.telemetry.update_low_voltages()
         print(dts.telemetry.one_five_voltage_ref)
         print(dts.telemetry.two_five_voltage_ref)
         print(dts.telemetry.five_voltage_ref)

--- a/Pidaq/Lib/dts_manager/dts_manager.py
+++ b/Pidaq/Lib/dts_manager/dts_manager.py
@@ -15,6 +15,14 @@ class DTSManager:
         self.rtd_3_temperature = None
         self.rtd_4_temperature = None
         self.rtd_5_temperature = None
+        self.analog_input_1 = None
+        self.analog_input_2 = None
+        self.analog_input_3 = None
+        self.analog_input_4 = None
+        self.one_five_voltage_ref = None
+        self.two_five_voltage_ref = None
+        self.five_voltage_ref = None
+        self.twelve_system_voltage = None
 
     def configure_motor(self, configuration: dict) -> None:
         # Extract commands from dict
@@ -59,6 +67,26 @@ class DTSManager:
             self.rtd_5_temperature = int.from_bytes(
                 self.bus.messages['0xa2'].data[4:2:-1], byteorder='big') / 10
 
+    def convert_low_voltages(self) -> None:
+        if self.bus.messages['0xa3'].data:
+            self.analog_input_1 = int.from_bytes(
+                self.bus.messages['0xa3'].data[0:2], byteorder='little') / 100
+            self.analog_input_2 = int.from_bytes(
+                self.bus.messages['0xa3'].data[2:4], byteorder='little') / 100
+            self.analog_input_3 = int.from_bytes(
+                self.bus.messages['0xa3'].data[4:6], byteorder='little') / 100
+            self.analog_input_4 = int.from_bytes(
+                self.bus.messages['0xa3'].data[6:], byteorder='little') / 100
+        if self.bus.messages['0xa9'].data:
+            self.one_five_voltage_ref = int.from_bytes(
+                self.bus.messages['0xa9'].data[0:2], byteorder='little') / 100
+            self.two_five_voltage_ref = int.from_bytes(
+                self.bus.messages['0xa9'].data[2:4], byteorder='little') / 100
+            self.five_voltage_ref = int.from_bytes(
+                self.bus.messages['0xa9'].data[4:6], byteorder='little') / 100
+            self.twelve_system_voltage = int.from_bytes(
+                self.bus.messages['0xa9'].data[6:], byteorder='little') / 100
+
     def convert_torques(self) -> None:
         pass
 
@@ -83,6 +111,8 @@ if __name__ == "__main__":
         dts.send_motor_command()
         current_message = dts.bus.read_bus()
         dts.bus.assign_message_data(current_message)
-        dts.convert_temperatures()
-        print(dts.module_a_temperature)
-        print(dts.module_b_temperature)
+        dts.convert_low_voltages()
+        print(dts.one_five_voltage_ref)
+        print(dts.two_five_voltage_ref)
+        print(dts.five_voltage_ref)
+        print(dts.twelve_system_voltage)

--- a/Pidaq/Lib/dts_manager/dts_manager.py
+++ b/Pidaq/Lib/dts_manager/dts_manager.py
@@ -127,6 +127,7 @@ class DTSTelemetry():
         convert_torques(self)
         convert_temperatures(self)
     '''
+
     def __init__(self, bus: can_manager.CanManager):
         ''' Takes reference to a CanManager instance to be used for receiving can messages'''
         self.bus = bus

--- a/Pidaq/Lib/dts_manager/dts_manager.py
+++ b/Pidaq/Lib/dts_manager/dts_manager.py
@@ -1,0 +1,9 @@
+
+
+class DTSManager:
+
+    def __init__(self):
+        pass
+
+    def configure_motor(self, configuration: dict) -> None:
+        pass

--- a/Pidaq/Lib/dts_manager/dts_manager.py
+++ b/Pidaq/Lib/dts_manager/dts_manager.py
@@ -231,128 +231,128 @@ class DTS():
             self.torque_timer_id = self.default_can_offset + 12
             self.modulation_index_id = self.default_can_offset + 13
 
-        def get_temp1_data(self):
-            return self.bus.messages[self.temp1_id].data
+        def get_temp1_data(self, start=0, stop=8):
+            return self.bus.messages[self.temp1_id].data[start:stop]
 
-        def get_temp2_data(self):
-            return self.bus.messages[self.temp2_id].data
+        def get_temp2_data(self, start=0, stop=8):
+            return self.bus.messages[self.temp2_id].data[start:stop]
 
-        def get_temp3_data(self):
-            return self.bus.messages[self.temp3_id].data
+        def get_temp3_data(self, start=0, stop=8):
+            return self.bus.messages[self.temp3_id].data[start:stop]
 
-        def get_analog_input_voltages_data(self):
-            return self.bus.messages[self.analog_inputs_id].data
+        def get_analog_input_voltages_data(self, start=0, stop=8):
+            return self.bus.messages[self.analog_inputs_id].data[start:stop]
 
-        def get_digital_input_status_data(self):
-            return self.bus.messages[self.digital_input_status_id].data
+        def get_digital_input_status_data(self, start=0, stop=8):
+            return self.bus.messages[self.digital_input_status_id].data[start:stop]
 
-        def get_motor_position_data(self):
-            return self.bus.messages[self.motor_position_id].data
+        def get_motor_position_data(self, start=0, stop=8):
+            return self.bus.messages[self.motor_position_id].data[start:stop]
 
-        def get_current_data(self):
-            return self.bus.messages[self.current_info_id].data
+        def get_current_data(self, start=0, stop=8):
+            return self.bus.messages[self.current_info_id].data[start:stop]
 
-        def get_voltage_data(self):
-            return self.bus.messages[self.voltage_info_id].data
+        def get_voltage_data(self, start=0, stop=8):
+            return self.bus.messages[self.voltage_info_id].data[start:stop]
 
-        def get_flux_data(self):
-            return self.bus.messages[self.flux_info_id].data
+        def get_flux_data(self, start=0, stop=8):
+            return self.bus.messages[self.flux_info_id].data[start:stop]
 
-        def get_internal_voltages_data(self):
-            return self.bus.messages[self.internal_voltages_id].data
+        def get_internal_voltages_data(self, start=0, stop=8):
+            return self.bus.messages[self.internal_voltages_id].data[start:stop]
 
-        def get_internal_states_data(self):
-            return self.bus.messages[self.internal_states_id].data
+        def get_internal_states_data(self, start=0, stop=8):
+            return self.bus.messages[self.internal_states_id].data[start:stop]
 
-        def get_faults_data(self):
-            return self.bus.messages[self.fault_codes_id].data
+        def get_faults_data(self, start=0, stop=8):
+            return self.bus.messages[self.fault_codes_id].data[start:stop]
 
-        def get_torque_timer_data(self):
-            return self.bus.messages[self.torque_timer_id].data
+        def get_torque_timer_data(self, start=0, stop=8):
+            return self.bus.messages[self.torque_timer_id].data[start:stop]
 
-        def get_modulation_index_data(self):
-            return self.bus.messages[self.modulation_index_id].data
+        def get_modulation_index_data(self, start=0, stop=8):
+            return self.bus.messages[self.modulation_index_id].data[start:stop]
 
         def convert_temperatures(self) -> None:
             if self.get_temp1_data():
                 self.module_a_temperature = int.from_bytes(
-                    self.get_temp1_data()[0:2], byteorder='little', signed=True) / 10
+                    self.get_temp1_data(0, 2), byteorder='little', signed=True) / 10
                 self.module_b_temperature = int.from_bytes(
-                    self.get_temp1_data()[2:4], byteorder='little', signed=True) / 10
+                    self.get_temp1_data(2, 4), byteorder='little', signed=True) / 10
                 self.module_c_temperature = int.from_bytes(
-                    self.get_temp1_data()[4:6], byteorder='little', signed=True) / 10
+                    self.get_temp1_data(4, 6), byteorder='little', signed=True) / 10
                 self.gate_driver_board_temperature = int.from_bytes(
-                    self.get_temp1_data()[6:], byteorder='little', signed=True) / 10
+                    self.get_temp1_data(6, 8), byteorder='little', signed=True) / 10
             if self.get_temp2_data():
                 self.control_board_temperature = int.from_bytes(
-                    self.get_temp2_data()[0:2], byteorder='little', signed=True) / 10
+                    self.get_temp2_data(0, 2), byteorder='little', signed=True) / 10
                 self.rtd_1_temperature = int.from_bytes(
-                    self.get_temp2_data()[2:4], byteorder='little', signed=True) / 10
+                    self.get_temp2_data(2, 4), byteorder='little', signed=True) / 10
                 self.rtd_2_temperature = int.from_bytes(
-                    self.get_temp2_data()[4:6], byteorder='little', signed=True) / 10
+                    self.get_temp2_data(4, 6), byteorder='little', signed=True) / 10
                 self.rtd_3_temperature = int.from_bytes(
-                    self.get_temp2_data()[6:], byteorder='little', signed=True) / 10
+                    self.get_temp2_data(6, 8), byteorder='little', signed=True) / 10
             if self.get_temp3_data():
                 self.rtd_4_temperature = int.from_bytes(
-                    self.get_temp3_data()[0:2], byteorder='little', signed=True) / 10
+                    self.get_temp3_data(0, 2), byteorder='little', signed=True) / 10
                 self.rtd_5_temperature = int.from_bytes(
-                    self.get_temp3_data()[2:4], byteorder='little', signed=True) / 10
+                    self.get_temp3_data(2, 4), byteorder='little', signed=True) / 10
                 self.motor_temperature = int.from_bytes(
-                    self.get_temp3_data()[4:6], byteorder='little', signed=True) / 10
+                    self.get_temp3_data(4, 6), byteorder='little', signed=True) / 10
 
         def convert_low_voltages(self) -> None:
             if self.get_analog_input_voltages_data():
                 self.analog_input_1 = int.from_bytes(
-                    self.get_analog_input_voltages_data()[0:2], byteorder='little', signed=True) / 100
+                    self.get_analog_input_voltages_data(0, 2), byteorder='little', signed=True) / 100
                 self.analog_input_2 = int.from_bytes(
-                    self.get_analog_input_voltages_data()[2:4], byteorder='little', signed=True) / 100
+                    self.get_analog_input_voltages_data(2, 4), byteorder='little', signed=True) / 100
                 self.analog_input_3 = int.from_bytes(
-                    self.get_analog_input_voltages_data()[4:6], byteorder='little', signed=True) / 100
+                    self.get_analog_input_voltages_data(4, 6), byteorder='little', signed=True) / 100
                 self.analog_input_4 = int.from_bytes(
-                    self.get_analog_input_voltages_data()[6:], byteorder='little', signed=True) / 100
+                    self.get_analog_input_voltages_data(6, 8), byteorder='little', signed=True) / 100
             if self.get_internal_voltages_data():
                 self.one_five_voltage_ref = int.from_bytes(
-                    self.get_internal_voltages_data()[0:2], byteorder='little', signed=True) / 100
+                    self.get_internal_voltages_data(0, 2), byteorder='little', signed=True) / 100
                 self.two_five_voltage_ref = int.from_bytes(
-                    self.get_internal_voltages_data()[2:4], byteorder='little', signed=True) / 100
+                    self.get_internal_voltages_data(2, 4), byteorder='little', signed=True) / 100
                 self.five_voltage_ref = int.from_bytes(
-                    self.get_internal_voltages_data()[4:6], byteorder='little', signed=True) / 100
+                    self.get_internal_voltages_data(4, 6), byteorder='little', signed=True) / 100
                 self.twelve_system_voltage = int.from_bytes(
-                    self.get_internal_voltages_data()[6:], byteorder='little', signed=True) / 100
+                    self.get_internal_voltages_data(6, 8), byteorder='little', signed=True) / 100
 
         def convert_high_voltages(self) -> None:
             if self.get_voltage_data():
                 self.dc_bus_voltage = int.from_bytes(
-                    self.get_voltage_data()[0:2], byteorder='little', signed=True) / 10
+                    self.get_voltage_data(0, 2), byteorder='little', signed=True) / 10
                 self.output_voltage = int.from_bytes(
-                    self.get_voltage_data()[2:4], byteorder='little', signed=True) / 10
+                    self.get_voltage_data(2, 4), byteorder='little', signed=True) / 10
                 self.vab_vd_voltage = int.from_bytes(
-                    self.get_voltage_data()[4:6], byteorder='little', signed=True) / 10
+                    self.get_voltage_data(4, 6), byteorder='little', signed=True) / 10
                 self.vbc_vq_voltage = int.from_bytes(
-                    self.get_voltage_data()[6:], byteorder='little', signed=True) / 10
+                    self.get_voltage_data(6, 8), byteorder='little', signed=True) / 10
 
         def convert_currents(self) -> None:
             if self.get_current_data():
                 self.phase_a_current = int.from_bytes(
-                    self.get_current_data()[0:2], byteorder='little', signed=True) / 10
+                    self.get_current_data(0, 2), byteorder='little', signed=True) / 10
                 self.phase_b_current = int.from_bytes(
-                    self.get_current_data()[2:4], byteorder='little', signed=True) / 10
+                    self.get_current_data(2, 4), byteorder='little', signed=True) / 10
                 self.phase_c_current = int.from_bytes(
-                    self.get_current_data()[4:6], byteorder='little', signed=True) / 10
+                    self.get_current_data(4,6), byteorder='little', signed=True) / 10
                 self.dc_bus_current = int.from_bytes(
-                    self.get_current_data()[6:], byteorder='little', signed=True) / 10
+                    self.get_current_data(6, 8), byteorder='little', signed=True) / 10
             if self.get_flux_data():
                 self.id_feedback = int.from_bytes(
-                    self.get_flux_data()[4:6], byteorder='little', signed=True) / 10
+                    self.get_flux_data(4, 6), byteorder='little', signed=True) / 10
                 self.iq_feedback = int.from_bytes(
-                    self.get_flux_data()[6:], byteorder='little', signed=True) / 10
+                    self.get_flux_data(6, 8), byteorder='little', signed=True) / 10
 
         def convert_angles(self) -> None:
             if self.get_motor_position_data():
                 self.motor_angle = int.from_bytes(
-                    self.get_motor_position_data(), byteorder='little', signed=True) / 10
+                    self.get_motor_position_data(0, 2), byteorder='little', signed=True) / 10
                 self.delta_filter_resolved = int.from_bytes(
-                    self.get_motor_position_data(), byteorder='little', signed=True) / 10
+                    self.get_motor_position_data(6, 8), byteorder='little', signed=True) / 10
 
         def convert_booleans(self) -> None:
             BIT_0 = 1 << 0
@@ -365,7 +365,7 @@ class DTS():
             BIT_7 = 1 << 7
             if self.get_digital_input_status_data():
                 digital_input_status = int.from_bytes(
-                    self.get_digital_input_status_data()[0:], byteorder='little', signed=False)
+                    self.get_digital_input_status_data(), byteorder='little', signed=False)
                 self.digital_input_1 = bool(digital_input_status & BIT_0)
                 self.digital_input_2 = bool(digital_input_status & BIT_1)
                 self.digital_input_3 = bool(digital_input_status & BIT_2)
@@ -378,12 +378,12 @@ class DTS():
         def convert_torques(self) -> None:
             if self.get_temp3_data():
                 self.torque_shudder = int.from_bytes(
-                    self.get_temp3_data()[6:], byteorder='little', signed=True) / 10
+                    self.get_temp3_data(6, 8), byteorder='little', signed=True) / 10
             if self.get_torque_timer_data():
                 self.commanded_torque = int.from_bytes(
-                    self.get_torque_timer_data()[0:2], byteorder='little', signed=True) / 10
+                    self.get_torque_timer_data(0, 2), byteorder='little', signed=True) / 10
                 self.torque_feedback = int.from_bytes(
-                    self.get_torque_timer_data()[2:4], byteorder='little', signed=True) / 10
+                    self.get_torque_timer_data(2, 4), byteorder='little', signed=True) / 10
 
 
 if __name__ == "__main__":

--- a/Pidaq/Lib/dts_manager/dts_manager.py
+++ b/Pidaq/Lib/dts_manager/dts_manager.py
@@ -1,6 +1,7 @@
 from can_manager import can_manager
 
 class DTSControl():
+
     def __init__(self, bus: can_manager.CanManager):
         self.bus = bus
 
@@ -69,94 +70,94 @@ class DTSTelemetry():
     def convert_temperatures(self) -> None:
         if self.bus.messages['0xa0'].data:
             self.module_a_temperature = int.from_bytes(
-                self.bus.messages['0xa0'].data[0:2], byteorder='little') / 10
+                self.bus.messages['0xa0'].data[0:2], byteorder='little', signed=True) / 10
             self.module_b_temperature = int.from_bytes(
-                self.bus.messages['0xa0'].data[2:4], byteorder='little') / 10
+                self.bus.messages['0xa0'].data[2:4], byteorder='little', signed=True) / 10
             self.module_c_temperature = int.from_bytes(
-                self.bus.messages['0xa0'].data[4:6], byteorder='little') / 10
+                self.bus.messages['0xa0'].data[4:6], byteorder='little', signed=True) / 10
             self.gate_driver_board_temperature = int.from_bytes(
-                self.bus.messages['0xa0'].data[6:], byteorder='little') / 10
+                self.bus.messages['0xa0'].data[6:], byteorder='little', signed=True) / 10
         if self.bus.messages['0xa1'].data:
             self.control_board_temperature = int.from_bytes(
-                self.bus.messages['0xa1'].data[0:2], byteorder='little') / 10
+                self.bus.messages['0xa1'].data[0:2], byteorder='little', signed=True) / 10
             self.rtd_1_temperature = int.from_bytes(
-                self.bus.messages['0xa1'].data[2:4], byteorder='little') / 10
+                self.bus.messages['0xa1'].data[2:4], byteorder='little', signed=True) / 10
             self.rtd_2_temperature = int.from_bytes(
-                self.bus.messages['0xa1'].data[4:6], byteorder='little') / 10
+                self.bus.messages['0xa1'].data[4:6], byteorder='little', signed=True) / 10
             self.rtd_3_temperature = int.from_bytes(
-                self.bus.messages['0xa1'].data[6:], byteorder='little') / 10
+                self.bus.messages['0xa1'].data[6:], byteorder='little', signed=True) / 10
         if self.bus.messages['0xa2'].data:
             self.rtd_4_temperature = int.from_bytes(
-                self.bus.messages['0xa2'].data[0:2], byteorder='little') / 10
+                self.bus.messages['0xa2'].data[0:2], byteorder='little', signed=True) / 10
             self.rtd_5_temperature = int.from_bytes(
-                self.bus.messages['0xa2'].data[2:4], byteorder='little') / 10
+                self.bus.messages['0xa2'].data[2:4], byteorder='little', signed=True) / 10
 
     def convert_low_voltages(self) -> None:
         if self.bus.messages['0xa3'].data:
             self.analog_input_1 = int.from_bytes(
-                self.bus.messages['0xa3'].data[0:2], byteorder='little') / 100
+                self.bus.messages['0xa3'].data[0:2], byteorder='little', signed=True) / 100
             self.analog_input_2 = int.from_bytes(
-                self.bus.messages['0xa3'].data[2:4], byteorder='little') / 100
+                self.bus.messages['0xa3'].data[2:4], byteorder='little', signed=True) / 100
             self.analog_input_3 = int.from_bytes(
-                self.bus.messages['0xa3'].data[4:6], byteorder='little') / 100
+                self.bus.messages['0xa3'].data[4:6], byteorder='little', signed=True) / 100
             self.analog_input_4 = int.from_bytes(
-                self.bus.messages['0xa3'].data[6:], byteorder='little') / 100
+                self.bus.messages['0xa3'].data[6:], byteorder='little', signed=True) / 100
         if self.bus.messages['0xa9'].data:
             self.one_five_voltage_ref = int.from_bytes(
-                self.bus.messages['0xa9'].data[0:2], byteorder='little') / 100
+                self.bus.messages['0xa9'].data[0:2], byteorder='little', signed=True) / 100
             self.two_five_voltage_ref = int.from_bytes(
-                self.bus.messages['0xa9'].data[2:4], byteorder='little') / 100
+                self.bus.messages['0xa9'].data[2:4], byteorder='little', signed=True) / 100
             self.five_voltage_ref = int.from_bytes(
-                self.bus.messages['0xa9'].data[4:6], byteorder='little') / 100
+                self.bus.messages['0xa9'].data[4:6], byteorder='little', signed=True) / 100
             self.twelve_system_voltage = int.from_bytes(
-                self.bus.messages['0xa9'].data[6:], byteorder='little') / 100
+                self.bus.messages['0xa9'].data[6:], byteorder='little', signed=True) / 100
 
     def convert_high_voltages(self) -> None:
         if self.bus.messages['0xa7'].data:
             self.dc_bus_voltage = int.from_bytes(
-                self.bus.messages['0xa7'].data[0:2], byteorder='little') / 10
+                self.bus.messages['0xa7'].data[0:2], byteorder='little', signed=True) / 10
             self.output_voltage = int.from_bytes(
-                self.bus.messages['0xa7'].data[2:4], byteorder='little') / 10
+                self.bus.messages['0xa7'].data[2:4], byteorder='little', signed=True) / 10
             self.vab_vd_voltage = int.from_bytes(
-                self.bus.messages['0xa7'].data[4:6], byteorder='little') / 10
+                self.bus.messages['0xa7'].data[4:6], byteorder='little', signed=True) / 10
             self.vbc_vq_voltage = int.from_bytes(
-                self.bus.messages['0xa7'].data[6:], byteorder='little') / 10
+                self.bus.messages['0xa7'].data[6:], byteorder='little', signed=True) / 10
 
     def convert_currents(self) -> None:
         if self.bus.messages['0xa6'].data:
             self.phase_a_current = int.from_bytes(
-                self.bus.messages['0xa6'].data[0:2], byteorder='little') / 10
+                self.bus.messages['0xa6'].data[0:2], byteorder='little', signed=True) / 10
             self.phase_b_current = int.from_bytes(
-                self.bus.messages['0xa6'].data[2:4], byteorder='little') / 10
+                self.bus.messages['0xa6'].data[2:4], byteorder='little', signed=True) / 10
             self.phase_c_current = int.from_bytes(
-                self.bus.messages['0xa6'].data[4:6], byteorder='little') / 10
+                self.bus.messages['0xa6'].data[4:6], byteorder='little', signed=True) / 10
             self.dc_bus_current = int.from_bytes(
-                self.bus.messages['0xa6'].data[6:], byteorder='little') / 10
+                self.bus.messages['0xa6'].data[6:], byteorder='little', signed=True) / 10
         if self.bus.messages['0xa8'].data:
             self.id_feedback = int.from_bytes(
-                self.bus.messages['0xa8'].data[4:6], byteorder='little') / 10
+                self.bus.messages['0xa8'].data[4:6], byteorder='little', signed=True) / 10
             self.iq_feedback = int.from_bytes(
-                self.bus.messages['0xa8'].data[6:], byteorder='little') / 10
+                self.bus.messages['0xa8'].data[6:], byteorder='little', signed=True) / 10
 
     def convert_angles(self) -> None:
         if self.bus.messages['0xa5'].data:
             self.motor_angle = int.from_bytes(
-                self.bus.messages['0xa5'].data[0:2], byteorder='little') / 10
+                self.bus.messages['0xa5'].data[0:2], byteorder='little', signed=True) / 10
             self.delta_filter_resolved = int.from_bytes(
-                self.bus.messages['0xa5'].data[6:], byteorder='little') / 10
+                self.bus.messages['0xa5'].data[6:], byteorder='little', signed=True) / 10
 
     def convert_booleans(self) -> None:
-        BIT_0 = 1
-        BIT_1 = 2
-        BIT_2 = 4
-        BIT_3 = 8
-        BIT_4 = 16
-        BIT_5 = 32
-        BIT_6 = 64
-        BIT_7 = 128
+        BIT_0 = 1<<0
+        BIT_1 = 1<<1
+        BIT_2 = 1<<2
+        BIT_3 = 1<<3
+        BIT_4 = 1<<4
+        BIT_5 = 1<<5
+        BIT_6 = 1<<6
+        BIT_7 = 1<<7
         if self.bus.messages['0xa4']:
             digital_input_status = int.from_bytes(
-                self.bus.messages['0xa4'].data[0:], byteorder='little')
+                self.bus.messages['0xa4'].data[0:], byteorder='little', signed=False)
             self.digital_input_1 = bool(digital_input_status & BIT_0)
             self.digital_input_2 = bool(digital_input_status & BIT_1)
             self.digital_input_3 = bool(digital_input_status & BIT_2)
@@ -169,12 +170,12 @@ class DTSTelemetry():
     def convert_torques(self) -> None:
         if self.bus.messages['0xa2'].data:
             self.torque_shudder = int.from_bytes(
-                self.bus.messages['0xa2'].data[6:], byteorder='little') / 10
+                self.bus.messages['0xa2'].data[6:], byteorder='little', signed=True) / 10
         if self.bus.messages['0xac'].data:
             self.commanded_torque = int.from_bytes(
-                self.bus.messages['0xac'].data[0:2], byteorder='little') / 10
+                self.bus.messages['0xac'].data[0:2], byteorder='little', signed=True) / 10
             self.torque_feedback = int.from_bytes(
-                self.bus.messages['0xac'].data[2:4], byteorder='little') / 10
+                self.bus.messages['0xac'].data[2:4], byteorder='little', signed=True) / 10
 
 
 if __name__ == "__main__":

--- a/Pidaq/Lib/dts_manager/message_config.json
+++ b/Pidaq/Lib/dts_manager/message_config.json
@@ -4,86 +4,69 @@
             {
                 "reading": "temperatures1",
                 "message_id": "0xa0",
-                "conversion_factor": "0",
-                "conversion_factor_type": "int"
+                "conversion_factor": 10
             },
             {
                 "reading": "temperatures2",
                 "message_id": "0xa1",
-                "conversion_factor": "0",
-                "conversion_factor_type": "int"
+                "conversion_factor": 10
             },
             {
                 "reading": "temperatures3",
                 "message_id": "0xa2",
-                "conversion_factor": "0",
-                "conversion_factor_type": "int"
+                "conversion_factor": 10
             },
             {
                 "reading": "analogInputVoltages",
                 "message_id": "0xa3",
-                "conversion_factor": "0",
-                "conversion_factor_type": "int"
+                "conversion_factor": 100
             },
             {
                 "reading": "digitalInputStatus",
                 "message_id": "0xa4",
-                "conversion_factor": "0",
-                "conversion_factor_type": "int"
+                "conversion_factor": 0
             },
             {
                 "reading": "motorPositionInformation",
-                "message_id": "0xa5",
-                "conversion_factor": "0",
-                "conversion_factor_type": "int"
+                "message_id": "0xa5"
             },
             {
                 "reading": "currentInformation",
                 "message_id": "0xa6",
-                "conversion_factor": "0",
-                "conversion_factor_type": "int"
+                "conversion_factor": 10
             },
             {
                 "reading": "voltageInformation",
                 "message_id": "0xa7",
-                "conversion_factor": "0",
-                "conversion_factor_type": "int"
+                "conversion_factor": 10
             },
             {
                 "reading": "fluxInformation",
                 "message_id": "0xa8",
-                "conversion_factor": "0",
-                "conversion_factor_type": "int"
+                "conversion_factor": { "flux": 1000, "current": 10 }
             },
             {
                 "reading": "internalVoltages",
                 "message_id": "0xa9",
-                "conversion_factor": "0",
-                "conversion_factor_type": "int"
+                "conversion_factor": 100
             },
             {
                 "reading": "internalStates",
-                "message_id": "0xaa",
-                "conversion_factor": "0",
-                "conversion_factor_type": "int"
+                "message_id": "0xaa"
             },
             {
                 "reading": "faultCodes",
-                "message_id": "0xab",
-                "conversion_factor": "0",
-                "conversion_factor_type": "int"
+                "message_id": "0xab"
             },
             {
                 "reading": "torque&timerInformation",
                 "message_id": "0xac",
-                "conversion_factor": "0",
-                "conversion_factor_type": "int"
+                "conversion_factor": 10
             },
             {
                 "reading": "modulationIndex&fluxWeakeningOutput",
                 "message_id": "0xad",
-                "conversion_factor": "0",
-                "conversion_factor_type": "int"
+                "conversion_factor": 10
             }
         ]
     },

--- a/Pidaq/Lib/dts_manager/message_config.json
+++ b/Pidaq/Lib/dts_manager/message_config.json
@@ -3,69 +3,69 @@
         "readings": [
             {
                 "reading": "temperatures1",
-                "message_id": "0xa0",
+                "message_id": 160,
                 "conversion_factor": 10
             },
             {
                 "reading": "temperatures2",
-                "message_id": "0xa1",
+                "message_id": 161,
                 "conversion_factor": 10
             },
             {
                 "reading": "temperatures3",
-                "message_id": "0xa2",
+                "message_id": 162,
                 "conversion_factor": 10
             },
             {
                 "reading": "analogInputVoltages",
-                "message_id": "0xa3",
+                "message_id": 163,
                 "conversion_factor": 100
             },
             {
                 "reading": "digitalInputStatus",
-                "message_id": "0xa4",
+                "message_id": 164,
                 "conversion_factor": 0
             },
             {
                 "reading": "motorPositionInformation",
-                "message_id": "0xa5"
+                "message_id": 165
             },
             {
                 "reading": "currentInformation",
-                "message_id": "0xa6",
+                "message_id": 166,
                 "conversion_factor": 10
             },
             {
                 "reading": "voltageInformation",
-                "message_id": "0xa7",
+                "message_id": 167,
                 "conversion_factor": 10
             },
             {
                 "reading": "fluxInformation",
-                "message_id": "0xa8",
+                "message_id": 168,
                 "conversion_factor": { "flux": 1000, "current": 10 }
             },
             {
                 "reading": "internalVoltages",
-                "message_id": "0xa9",
+                "message_id": 169,
                 "conversion_factor": 100
             },
             {
                 "reading": "internalStates",
-                "message_id": "0xaa"
+                "message_id": 170
             },
             {
                 "reading": "faultCodes",
-                "message_id": "0xab"
+                "message_id": 171
             },
             {
                 "reading": "torque&timerInformation",
-                "message_id": "0xac",
+                "message_id": 172,
                 "conversion_factor": 10
             },
             {
                 "reading": "modulationIndex&fluxWeakeningOutput",
-                "message_id": "0xad",
+                "message_id": 173,
                 "conversion_factor": 10
             }
         ]

--- a/Pidaq/Lib/dts_manager/message_config.json
+++ b/Pidaq/Lib/dts_manager/message_config.json
@@ -1,0 +1,110 @@
+{
+    "dts": {
+        "readings": [
+            {
+                "reading": "temperatures1",
+                "message_id": "0xa0",
+                "conversion_factor": "0",
+                "conversion_factor_type": "int"
+            },
+            {
+                "reading": "temperatures2",
+                "message_id": "0xa1",
+                "conversion_factor": "0",
+                "conversion_factor_type": "int"
+            },
+            {
+                "reading": "temperatures3",
+                "message_id": "0xa2",
+                "conversion_factor": "0",
+                "conversion_factor_type": "int"
+            },
+            {
+                "reading": "analogInputVoltages",
+                "message_id": "0xa3",
+                "conversion_factor": "0",
+                "conversion_factor_type": "int"
+            },
+            {
+                "reading": "digitalInputStatus",
+                "message_id": "0xa4",
+                "conversion_factor": "0",
+                "conversion_factor_type": "int"
+            },
+            {
+                "reading": "motorPositionInformation",
+                "message_id": "0xa5",
+                "conversion_factor": "0",
+                "conversion_factor_type": "int"
+            },
+            {
+                "reading": "currentInformation",
+                "message_id": "0xa6",
+                "conversion_factor": "0",
+                "conversion_factor_type": "int"
+            },
+            {
+                "reading": "voltageInformation",
+                "message_id": "0xa7",
+                "conversion_factor": "0",
+                "conversion_factor_type": "int"
+            },
+            {
+                "reading": "fluxInformation",
+                "message_id": "0xa8",
+                "conversion_factor": "0",
+                "conversion_factor_type": "int"
+            },
+            {
+                "reading": "internalVoltages",
+                "message_id": "0xa9",
+                "conversion_factor": "0",
+                "conversion_factor_type": "int"
+            },
+            {
+                "reading": "internalStates",
+                "message_id": "0xaa",
+                "conversion_factor": "0",
+                "conversion_factor_type": "int"
+            },
+            {
+                "reading": "faultCodes",
+                "message_id": "0xab",
+                "conversion_factor": "0",
+                "conversion_factor_type": "int"
+            },
+            {
+                "reading": "torque&timerInformation",
+                "message_id": "0xac",
+                "conversion_factor": "0",
+                "conversion_factor_type": "int"
+            },
+            {
+                "reading": "modulationIndex&fluxWeakeningOutput",
+                "message_id": "0xad",
+                "conversion_factor": "0",
+                "conversion_factor_type": "int"
+            }
+        ]
+    },
+    "suspension": {
+        "readings": [
+            {
+                "reading": "Placeholder",
+                "message_id": "Placeholder (Will hold string representation of id (0x0A for example)",
+                "conversion_factor": "Placeholder",
+                "conversion_factor_type": "Placeholder"
+            }
+        ]
+    },
+    "windtunnel": {
+        "readings": [
+            {
+                "reading": "Placeholder",
+                "message_id": "Placeholder (Will hold string representation of id (0x0A for example)",
+                "conversion_factor": "Placeholder",
+                "conversion_factor_type": "Placeholder"
+            }
+        ]
+    }
+}

--- a/Pidaq/Lib/dts_manager/message_config.json
+++ b/Pidaq/Lib/dts_manager/message_config.json
@@ -28,7 +28,8 @@
             },
             {
                 "reading": "motorPositionInformation",
-                "message_id": 165
+                "message_id": 165,
+                "conversion_factor": 0
             },
             {
                 "reading": "currentInformation",
@@ -43,7 +44,10 @@
             {
                 "reading": "fluxInformation",
                 "message_id": 168,
-                "conversion_factor": { "flux": 1000, "current": 10 }
+                "conversion_factor": {
+                    "flux": 1000,
+                    "current": 10
+                }
             },
             {
                 "reading": "internalVoltages",
@@ -52,11 +56,13 @@
             },
             {
                 "reading": "internalStates",
-                "message_id": 170
+                "message_id": 170,
+                "conversion_factor": 0
             },
             {
                 "reading": "faultCodes",
-                "message_id": 171
+                "message_id": 171,
+                "conversion_factor": 0
             },
             {
                 "reading": "torque&timerInformation",

--- a/Pidaq/Lib/dts_manager/message_config.json
+++ b/Pidaq/Lib/dts_manager/message_config.json
@@ -14,7 +14,10 @@
             {
                 "reading": "temperatures3",
                 "message_id": 162,
-                "conversion_factor": 10
+                "conversion_factor": {
+                    "temp": 10,
+                    "torque": 10
+                }
             },
             {
                 "reading": "analogInputVoltages",
@@ -24,12 +27,16 @@
             {
                 "reading": "digitalInputStatus",
                 "message_id": 164,
-                "conversion_factor": 0
+                "conversion_factor": 1
             },
             {
                 "reading": "motorPositionInformation",
                 "message_id": 165,
-                "conversion_factor": 0
+                "conversion_factor": {
+                    "angle": 10,
+                    "angular_velocity": 1,
+                    "frequency": 10
+                }
             },
             {
                 "reading": "currentInformation",
@@ -57,12 +64,12 @@
             {
                 "reading": "internalStates",
                 "message_id": 170,
-                "conversion_factor": 0
+                "conversion_factor": 1
             },
             {
                 "reading": "faultCodes",
                 "message_id": 171,
-                "conversion_factor": 0
+                "conversion_factor": 1
             },
             {
                 "reading": "torque&timerInformation",


### PR DESCRIPTION
## DTS Motor Inverter Interface initial pull request
This PR contains the initial implementation of the DTS Interface, as well as the DTS motor inverter simulator, that we will use for testing. Other than a few small updates to the CanManager, and the can-sender and receiver examples, the main changes can be found in `Pidaq/Examples/dts_simulator/dts_simulator.py` and `Pidaq/Lib/dts_manager/dts_manager.py`.

### DTS Control
This class allows for control commands to be sent to the motor inverter, based on the CAN message format defined by the manufacturer

### DTS Telemetry
This class allows for the reception for (almost) all the information messages. The interface extracts the info from each can message byte, and converts it based off of the conversion factors outlined in the [CAN communications manual](https://sites.google.com/mun.ca/testing-software-wiki/documentation/Datasheets). All of the data fields are stored as member variables within the class. This code definitely needs a good refactor, but I'd like to get a bit of feedback first before that happens.

### DTS Simulator
This class utilizes the SocketCan linux protocol to send simulated Can messages that we would expect to receive from the real thing. The simulator will time out if it doesn't receive a control message from the interface every 0.5s. This code is not super clean, but functions as intended and is not production code anyways.

### Things left to do:
- Refactor DTS Manager after feedback
- docstrings and READMEs