### PR TITLE
Add Multiprocessing Example Folder with Pipe Example 

### DIFF
--- a/Pidaq/Examples/Multiprocessing/pipe_example.py
+++ b/Pidaq/Examples/Multiprocessing/pipe_example.py
@@ -1,0 +1,78 @@
+""" pipe_example.py
+
+Proof of Concept - Controlling a process from another process using a pipe
+This example demonstrates the control of one process from another using a Pipe.
+The process would be very similar if using a Pool/Queue/Duplex pipe.
+
+In this example the active_test thread controls the telem thread by sending
+it messages through a unidirectional pipe. After the telem thread prints an 
+arbitrary message for 5 seconds, The active_test thread launches and tells 
+the telem thread to print a new message, then 5 seconds later tells it to close.
+
+Simply run using python3 pipe_example.py
+
+"""
+
+
+from multiprocessing import Pipe, Process
+from time import sleep
+
+
+def telem(timeout: float, message: str, conn):
+    """ Print messages received through a pipe until True is received """
+    stopLoop = False
+    while(not stopLoop):
+        # Read pipe and update number
+        # Poll for timeout seconds, returns true if data is available 
+        if conn.poll(timeout=timeout):
+            message = conn.recv()
+            if isinstance(message, bool):
+                stopLoop = message
+        print(message)
+    
+
+def active_test(newMsg: str, conn):
+    """ Tell telem thread to print a new message or to close """
+    # Send the new message to print through the pipe
+    conn.send(newMsg)
+    sleep(5)
+    
+    # "Swap back to the old database"
+    conn.send("Test complete - using standby database")
+    sleep(5)
+    
+    # Send command to "close" the telem thread
+    conn.send(True)
+    
+    # Close the conn when finished sending data - probably a good idea
+    conn.close() 
+
+
+if __name__ == "__main__":
+    # Launch the telemetry thread and commander threads
+
+    # Configure initial message and updated message
+    initialMsg = "Using default database"
+    newMsg = "Test started - using production database"
+    timeout = 1
+    
+    # Create pipe endpoint connection objects (unidirectional)
+    parent_conn, child_conn = Pipe(duplex=False)
+    
+    # Create "telemetry" process
+    p_telem = Process(target=telem, args=(timeout, initialMsg, parent_conn))
+    
+    # Create "active_test" process
+    p_active_test = Process(target=active_test, args=(newMsg, child_conn))
+    
+    # Run telem thread for 10 seconds before launching active test
+    p_telem.start()
+    sleep(5)
+    p_active_test.start()
+    
+    # Wait for both processes to complete
+    p_active_test.join()
+    p_telem.join()
+    
+    print("Child Processes Complete")
+    


### PR DESCRIPTION
This pull request contains a single commit which adds a single file:
- `pipe_example.py`

This is an example script to act as a proof of concept for our plan to control the telemetry thread's active database from another
"active_test" thread. 

First, the mock telem process is launched, printing "Using default database" in a while loop.

5 seconds later, the active_test process is launched and sends a message through a unidirectional pipe that tells the telem process to begin printing "Swapped databases to production" to emulate what will actually occur (a call to db.set_active_db() or something of the like)

After 5 more seconds, the active_test thread tells the telem thread to exit the while loop, before closing the pipe and ending the program.

This file has no dependencies except python3, and can easily be run using "python3 pipe_example.py"